### PR TITLE
Add QSPI controller RTL modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# QSPI-Flash-Device-Controller
+# QSPI Flash Device Controller
+
+This project provides Verilog building blocks for a parameterizable Quad-SPI (QSPI) flash controller. The IP core bridges a host processor to external QSPI flash memories and is intended for FPGA or ASIC integration.
+
+## RTL Modules
+- **csr.v** – APB-accessible control/status register block.
+- **qspi_fsm.v** – Finite state machine that issues flash command sequences.
+- **fifo.v** – Simple 32-bit wide FIFO used for buffering data.
+- **axi_read_block.v** – AXI4-Lite helper to read a block of memory into the FIFO.
+- **axi_write_block.v** – AXI4-Lite helper to write FIFO contents to memory.
+- **qspi_device.v** – Behavioural flash memory model for simulation.
+
+## Development Notes
+The repository follows a synchronous-reset coding style. To run basic lint and compilation checks:
+
+```bash
+verilator --lint-only -Wno-fatal rtl/axi_read_block.v rtl/axi_write_block.v rtl/csr.v rtl/fifo.v rtl/qspi_fsm.v
+iverilog -g2012 -s qspi_fsm -o /tmp/qspi_fsm.vvp rtl/axi_read_block.v rtl/axi_write_block.v rtl/csr.v rtl/fifo.v rtl/qspi_fsm.v
+```
+
+These commands perform Verilator linting and compile the FSM with Icarus Verilog.

--- a/rtl/axi_read_block.v
+++ b/rtl/axi_read_block.v
@@ -1,0 +1,96 @@
+module axi_read_block (
+    input wire          clk,
+    input wire          rst_n,
+
+    input wire          start,
+    input wire  [31:0]  addr,
+    input wire  [15:0]  transfer_size,
+
+    output reg  [31:0]  araddr,
+    output reg          arvalid,
+    input  wire         arready,
+
+    input  wire         rvalid,
+    input  wire [31:0]  rdata,
+    output reg          rready,
+
+    output reg  [31:0]  data_out,
+    output reg          wr_en,
+    input  wire         full,
+
+    output reg          busy,
+    output reg          done
+);
+
+    localparam IDLE  = 2'd0,
+               ADDR  = 2'd1,
+               DATA  = 2'd2,
+               RESP  = 2'd3;
+
+    reg [1:0] state;
+    reg [15:0] count;
+    reg [31:0] addr_reg;
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            state     <= IDLE;
+            count     <= 0;
+            addr_reg  <= 0;
+            araddr    <= 0;
+            arvalid   <= 0;
+            rready    <= 0;
+            data_out  <= 0;
+            wr_en     <= 0;
+            busy      <= 0;
+            done      <= 0;
+        end else begin
+            arvalid <= 0;
+            rready  <= 0;
+            wr_en   <= 0;
+            done    <= 0;
+            busy    <= (state != IDLE);
+
+            case (state)
+                IDLE: begin
+                    if (start && !full) begin
+                        addr_reg <= {addr[31:2], 2'b00};
+                        count    <= 0;
+                        araddr   <= {addr[31:2], 2'b00};
+                        arvalid  <= 1;
+                        state    <= ADDR;
+                    end
+                end
+
+                ADDR: begin
+                    if (arready) begin
+                        rready  <= 1;
+                        state   <= DATA;
+                    end
+                end
+
+                DATA: begin
+                    if (rvalid && !full) begin
+                        data_out <= rdata;
+                        wr_en    <= 1;
+                        rready   <= 1;
+                        count    <= count + 4;
+                        if (count + 4 < transfer_size) begin
+                            addr_reg <= addr_reg + 4;
+                            araddr   <= addr_reg + 4;
+                            arvalid  <= 1;
+                            state    <= ADDR;
+                        end else begin
+                            state <= RESP;
+                        end
+                    end
+                end
+
+                RESP: begin
+                    done  <= 1;
+                    state <= IDLE;
+                end
+            endcase
+        end
+    end
+
+endmodule

--- a/rtl/axi_write_block.v
+++ b/rtl/axi_write_block.v
@@ -1,0 +1,112 @@
+module axi_write_block (
+    input wire          clk,
+    input wire          rst_n,
+
+    input wire          start,
+    input wire  [31:0]  addr,
+    input wire  [15:0]  transfer_size,
+
+    // AXI4-lite write address channel
+    output reg  [31:0]  awaddr,
+    output reg          awvalid,
+    input  wire         awready,
+
+    // AXI4-lite write data channel
+    output reg  [31:0]  wdata,
+    output reg          wvalid,
+    output reg  [3:0]   wstrb,
+    input  wire         wready,
+
+    // AXI4-lite write response channel
+    input  wire         bvalid,
+    output reg          bready,
+
+    // FIFO input
+    input  wire  [31:0] data_in,
+    input  wire         empty,
+    output reg          rd_en,
+
+    output reg          busy,
+    output reg          done
+);
+
+    localparam IDLE  = 2'd0,
+               ADDR  = 2'd1,
+               DATA  = 2'd2,
+               RESP  = 2'd3;
+
+    reg [1:0] state;
+    reg [15:0] count;
+    reg [31:0] addr_reg;
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            state     <= IDLE;
+            count     <= 0;
+            addr_reg  <= 0;
+            awaddr    <= 0;
+            awvalid   <= 0;
+            wdata     <= 0;
+            wvalid    <= 0;
+            wstrb     <= 4'b1111;
+            bready    <= 0;
+            rd_en     <= 0;
+            busy      <= 0;
+            done      <= 0;
+        end else begin
+            awvalid <= 0;
+            wvalid  <= 0;
+            bready  <= 0;
+            rd_en   <= 0;
+            done    <= 0;
+            busy    <= (state != IDLE);
+
+            case (state)
+                IDLE: begin
+                    if (start && !empty) begin
+                        addr_reg <= {addr[31:2], 2'b00};
+                        count    <= 0;
+                        awaddr   <= {addr[31:2], 2'b00};
+                        awvalid  <= 1;
+                        state    <= ADDR;
+                    end
+                end
+
+                ADDR: begin
+                    if (awready) begin
+                        if (!empty) begin
+                            rd_en   <= 1;
+                            wdata   <= data_in;
+                            wvalid  <= 1;
+                            wstrb   <= 4'b1111;
+                            state   <= DATA;
+                        end
+                    end
+                end
+
+                DATA: begin
+                    if (wready) begin
+                        bready   <= 1;
+                        count    <= count + 4;
+                        if (count + 4 < transfer_size) begin
+                            addr_reg <= addr_reg + 4;
+                            awaddr   <= addr_reg + 4;
+                            awvalid  <= 1;
+                            state    <= ADDR;
+                        end else begin
+                            state <= RESP;
+                        end
+                    end
+                end
+
+                RESP: begin
+                    if (bvalid) begin
+                        done  <= 1;
+                        state <= IDLE;
+                    end
+                end
+            endcase
+        end
+    end
+
+endmodule

--- a/rtl/csr.v
+++ b/rtl/csr.v
@@ -1,0 +1,435 @@
+// csr.v — QSPI CSR (docx-aligned)
+// - Two-phase APB timing
+// - W1C INT_STAT with rising-edge qualifiers
+// - CTRL[8] CMD_TRIGGER is W1S on byte1 and cleared by CE via cmd_trigger_clr_i
+// - Reserved-bit write masks
+// - RO/invalid-write -> PSLVERR; unmapped reads return 0 (no error)
+// - Optional APB4 byte strobes via HAS_PSTRB (default off; acts as 4'b1111)
+// - Configurable APB decode window via APB_WINDOW_LSB (default 4KB)
+// - INT_EN byte-lane fix: bits [4:0] use pstrb_eff[0]
+// - Optional WP bit via HAS_WP (default 0 = not writeable / reads 0)
+module csr #(
+  parameter integer APB_ADDR_WIDTH = 12,
+  parameter integer APB_WINDOW_LSB = 12, // 4KB window
+  parameter integer HAS_PSTRB = 0, // 0: ignore pstrb; 1: honor pstrb
+  parameter integer HAS_WP = 0 // 0: CTRL[10] not writeable/0; 1: writeable
+)(
+  // APB
+  input wire pclk,
+  input wire presetn,
+  input wire psel,
+  input wire penable,
+  input wire pwrite,
+  input wire [APB_ADDR_WIDTH-1:0] paddr,
+  input wire [31:0] pwdata,
+  input wire [3:0] pstrb, // tie 4'b1111 if HAS_PSTRB=0
+  output reg [31:0] prdata,
+  output wire pready,
+  output reg pslverr,
+  // CTRL
+  output wire enable_o,
+  output wire xip_en_o,
+  output wire quad_en_o,
+  output wire cpol_o,
+  output wire cpha_o,
+  output wire lsb_first_o,
+  output wire cmd_trigger_o, // W1S; cleared by CE
+  output wire dma_en_o,
+  output wire mode_en_o,
+  output wire hold_en_o,
+  output wire wp_en_o, // optional (HAS_WP)
+  // CE clear for CMD_TRIGGER
+  input wire cmd_trigger_clr_i,
+  // Clock & CS
+  output wire [2:0] clk_div_o,
+  output wire cs_auto_o,
+  output wire [1:0] cs_level_o,
+  output wire [1:0] cs_delay_o,
+  // XIP
+  output wire [1:0] xip_addr_bytes_o,
+  output wire [1:0] xip_data_lanes_o,
+  output wire [3:0] xip_dummy_cycles_o,
+  output wire xip_cont_read_o,
+  output wire xip_mode_en_o,
+  output wire xip_write_en_o,
+  output wire [7:0] xip_read_op_o,
+  output wire [7:0] xip_mode_bits_o,
+  output wire [7:0] xip_write_op_o,
+  // Command mode
+  output wire [1:0] cmd_lanes_o,
+  output wire [1:0] addr_lanes_o,
+  output wire [1:0] data_lanes_o,
+  output wire [1:0] addr_bytes_o,
+  output wire mode_en_cfg_o, // tied to CTRL.mode_en
+  output wire [3:0] dummy_cycles_o,
+  output wire is_write_o, // 0=READ, 1=WRITE
+  output wire [7:0] opcode_o,
+  output wire [7:0] mode_bits_o,
+  output wire [31:0] cmd_addr_o,
+  output wire [31:0] cmd_len_o,
+  output wire [7:0] extra_dummy_o,
+  // DMA
+  output wire [3:0] burst_size_o,
+  output wire dma_dir_o,
+  output wire incr_addr_o,
+  output wire [31:0] dma_addr_o,
+  output wire [31:0] dma_len_o,
+  // FIFO windows
+  output wire [31:0] fifo_tx_data_o,
+  output wire fifo_tx_we_o,
+  input wire [31:0] fifo_rx_data_i,
+  output wire fifo_rx_re_o,
+  // INT
+  output wire [4:0] int_en_o,
+  input wire cmd_done_set_i,
+  input wire dma_done_set_i,
+  input wire err_set_i,
+  input wire fifo_tx_empty_set_i,
+  input wire fifo_rx_full_set_i,
+  // STATUS live
+  input wire busy_i,
+  input wire xip_active_i,
+  input wire cmd_done_i,
+  input wire dma_done_i,
+  input wire [3:0] tx_level_i,
+  input wire [3:0] rx_level_i,
+  input wire tx_empty_i,
+  input wire rx_full_i,
+  input wire timeout_i,
+  input wire overrun_i,
+  input wire underrun_i,
+  input wire axi_err_i,
+  output wire irq
+);
+  // ---------------- Address window & constants -------------
+  localparam integer WIN = APB_WINDOW_LSB;
+  wire [WIN-1:0] a = paddr[WIN-1:0];
+  // WIN-wide addresses (map stops at 0x050)
+  localparam [WIN-1:0] ID_ADDR = 'h000;
+  localparam [WIN-1:0] CTRL_ADDR = 'h004;
+  localparam [WIN-1:0] STATUS_ADDR = 'h008;
+  localparam [WIN-1:0] INT_EN_ADDR = 'h00C;
+  localparam [WIN-1:0] INT_STAT_ADDR = 'h010; // W1C
+  localparam [WIN-1:0] CLK_DIV_ADDR = 'h014;
+  localparam [WIN-1:0] CS_CTRL_ADDR = 'h018;
+  localparam [WIN-1:0] XIP_CFG_ADDR = 'h01C;
+  localparam [WIN-1:0] XIP_CMD_ADDR = 'h020;
+  localparam [WIN-1:0] CMD_CFG_ADDR = 'h024;
+  localparam [WIN-1:0] CMD_OP_ADDR = 'h028;
+  localparam [WIN-1:0] CMD_ADDR_ADDR = 'h02C;
+  localparam [WIN-1:0] CMD_LEN_ADDR = 'h030;
+  localparam [WIN-1:0] CMD_DUMMY_ADDR = 'h034;
+  localparam [WIN-1:0] DMA_CFG_ADDR = 'h038;
+  localparam [WIN-1:0] DMA_DST_ADDR = 'h03C; // DRAM destination
+  localparam [WIN-1:0] DMA_LEN_ADDR = 'h040;
+  localparam [WIN-1:0] FIFO_TX_ADDR = 'h044; // write
+  localparam [WIN-1:0] FIFO_RX_ADDR = 'h048; // read
+  localparam [WIN-1:0] FIFO_STAT_ADDR = 'h04C;
+  localparam [WIN-1:0] ERR_STAT_ADDR = 'h050;
+  // ---------------- Registers ------------------------------
+  reg [31:0] ctrl_reg, int_en_reg, int_stat_reg;
+  reg [31:0] clk_div_reg, cs_ctrl_reg;
+  reg [31:0] xip_cfg_reg, xip_cmd_reg;
+  reg [31:0] cmd_cfg_reg, cmd_op_reg, cmd_addr_reg, cmd_len_reg, cmd_dummy_reg;
+  reg [31:0] dma_cfg_reg, dma_addr_reg, dma_len_reg;
+  // Fixed IP ID (per spec)
+  localparam [31:0] ID_VALUE = 32'h1A001081;
+  // Read-only composites
+  wire [31:0] id_reg = ID_VALUE;
+  wire [31:0] status_reg = {26'd0, busy_i, xip_active_i, cmd_done_i, dma_done_i, 2'b00};
+  wire [31:0] fifo_stat_reg = {22'd0, rx_full_i, tx_empty_i, rx_level_i[3:0], tx_level_i[3:0]};
+  wire [31:0] err_stat_reg = {28'd0, axi_err_i, underrun_i, overrun_i, timeout_i};
+  // ---------------- APB timing -----------------------------
+  wire setup_phase = psel & ~penable;
+  wire access_phase = psel & penable;
+  wire write_phase = access_phase & pwrite;
+  wire read_phase = access_phase & ~pwrite;
+  assign pready = 1'b1;
+  // Effective strobes (when HAS_PSTRB=0, behaves as full-word writes)
+  wire [3:0] pstrb_eff = (HAS_PSTRB!=0) ? pstrb : 4'b1111;
+  // Valid/RO decode
+  reg valid_addr;
+  reg ro_addr;
+  always @(*) begin
+    valid_addr = 1'b0;
+    ro_addr = 1'b0;
+    if (access_phase) begin
+      case (a)
+        ID_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b1; end
+        CTRL_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        STATUS_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b1; end
+        INT_EN_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        INT_STAT_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end // W1C on write
+        CLK_DIV_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        CS_CTRL_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        XIP_CFG_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        XIP_CMD_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        CMD_CFG_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        CMD_OP_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        CMD_ADDR_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        CMD_LEN_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        CMD_DUMMY_ADDR: begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        DMA_CFG_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        DMA_DST_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        DMA_LEN_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end
+        FIFO_TX_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b0; end // WO side-effect
+        FIFO_RX_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b1; end
+        FIFO_STAT_ADDR: begin valid_addr = 1'b1; ro_addr = 1'b1; end
+        ERR_STAT_ADDR : begin valid_addr = 1'b1; ro_addr = 1'b1; end
+        default : begin valid_addr = 1'b0; ro_addr = 1'b0; end
+      endcase
+    end
+  end
+  // PSLVERR: assert on invalid WRITE or WRITE to RO
+  always @(*) begin
+    if (access_phase && pwrite && (!valid_addr || ro_addr))
+      pslverr = 1'b1;
+    else
+      pslverr = 1'b0;
+  end
+  // Global write gate (valid, and not RO)
+  wire wr_ok = write_phase & valid_addr & ~ro_addr;
+  // FIFO side-effects
+  assign fifo_tx_we_o = wr_ok & (a == FIFO_TX_ADDR);
+  assign fifo_tx_data_o = pwdata;
+  assign fifo_rx_re_o = read_phase & valid_addr & (a == FIFO_RX_ADDR);
+  // ---------------- Write masks ----------------------------
+  // Effective CTRL mask (tighten if HAS_WP==0)
+  wire [31:0] CTRL_WMASK_EFF = HAS_WP ? 32'h0000_03FF : 32'h0000_01FF;
+  // NOTE: masked bits read as 0; if you need write-any/read-same, remove masks
+  wire [31:0] CTRL_WMASK = 32'h0000_03FF; // nominal (used for readback checks)
+  wire [31:0] CLKDIV_WMASK = 32'h0000_000F;
+  wire [31:0] CSCTRL_WMASK = 32'h0000_000F;
+  wire [31:0] XIPCFG_WMASK = 32'h0000_3FFF;
+  wire [31:0] XIPCMD_WMASK = 32'h00FF_FFFF;
+  wire [31:0] CMDCFG_WMASK = 32'h0000_1FFF;
+  wire [31:0] CMDOP_WMASK = 32'h0000_FFFF;
+  wire [31:0] CMDDMY_WMASK = 32'h0000_00FF;
+  wire [31:0] DMACFG_WMASK = 32'h0000_003F;
+  // Pre-masked data per target reg
+  // For CTRL: ensure bit[8] (trigger) is forced 0 into the stored ctrl_reg
+  wire [31:0] CTRL_PMW_base = pwdata & CTRL_WMASK_EFF;
+  wire [31:0] CTRL_PMW = { CTRL_PMW_base[31:9], 1'b0, CTRL_PMW_base[7:0] }; // clear bit8
+  wire [31:0] CLKDIV_PMW = pwdata & CLKDIV_WMASK;
+  wire [31:0] CSCTRL_PMW = pwdata & CSCTRL_WMASK;
+  wire [31:0] XIPCFG_PMW = pwdata & XIPCFG_WMASK;
+  wire [31:0] XIPCMD_PMW = pwdata & XIPCMD_WMASK;
+  wire [31:0] CMDCFG_PMW = pwdata & CMDCFG_WMASK;
+  wire [31:0] CMDOP_PMW = pwdata & CMDOP_WMASK;
+  wire [31:0] CMDDMY_PMW = pwdata & CMDDMY_WMASK;
+  wire [31:0] DMACFG_PMW = pwdata & DMACFG_WMASK;
+  // Byte-strobe merged write data (no functions)
+  wire [31:0] CTRL_WDATA = { pstrb_eff[3] ? CTRL_PMW[31:24] : ctrl_reg[31:24],
+                               pstrb_eff[2] ? CTRL_PMW[23:16] : ctrl_reg[23:16],
+                               pstrb_eff[1] ? CTRL_PMW[15:8] : ctrl_reg[15:8],
+                               pstrb_eff[0] ? CTRL_PMW[7:0] : ctrl_reg[7:0] };
+  wire [31:0] CLKDIV_WDATA = { pstrb_eff[3] ? CLKDIV_PMW[31:24] : clk_div_reg[31:24],
+                               pstrb_eff[2] ? CLKDIV_PMW[23:16] : clk_div_reg[23:16],
+                               pstrb_eff[1] ? CLKDIV_PMW[15:8] : clk_div_reg[15:8],
+                               pstrb_eff[0] ? CLKDIV_PMW[7:0] : clk_div_reg[7:0] };
+  wire [31:0] CSCTRL_WDATA = { pstrb_eff[3] ? CSCTRL_PMW[31:24] : cs_ctrl_reg[31:24],
+                               pstrb_eff[2] ? CSCTRL_PMW[23:16] : cs_ctrl_reg[23:16],
+                               pstrb_eff[1] ? CSCTRL_PMW[15:8] : cs_ctrl_reg[15:8],
+                               pstrb_eff[0] ? CSCTRL_PMW[7:0] : cs_ctrl_reg[7:0] };
+  wire [31:0] XIPCFG_WDATA = { pstrb_eff[3] ? XIPCFG_PMW[31:24] : xip_cfg_reg[31:24],
+                               pstrb_eff[2] ? XIPCFG_PMW[23:16] : xip_cfg_reg[23:16],
+                               pstrb_eff[1] ? XIPCFG_PMW[15:8] : xip_cfg_reg[15:8],
+                               pstrb_eff[0] ? XIPCFG_PMW[7:0] : xip_cfg_reg[7:0] };
+  wire [31:0] XIPCMD_WDATA = { pstrb_eff[3] ? XIPCMD_PMW[31:24] : xip_cmd_reg[31:24],
+                               pstrb_eff[2] ? XIPCMD_PMW[23:16] : xip_cmd_reg[23:16],
+                               pstrb_eff[1] ? XIPCMD_PMW[15:8] : xip_cmd_reg[15:8],
+                               pstrb_eff[0] ? XIPCMD_PMW[7:0] : xip_cmd_reg[7:0] };
+  wire [31:0] CMDCFG_WDATA = { pstrb_eff[3] ? CMDCFG_PMW[31:24] : cmd_cfg_reg[31:24],
+                               pstrb_eff[2] ? CMDCFG_PMW[23:16] : cmd_cfg_reg[23:16],
+                               pstrb_eff[1] ? CMDCFG_PMW[15:8] : cmd_cfg_reg[15:8],
+                               pstrb_eff[0] ? CMDCFG_PMW[7:0] : cmd_cfg_reg[7:0] };
+  wire [31:0] CMDOP_WDATA = { pstrb_eff[3] ? CMDOP_PMW[31:24] : cmd_op_reg[31:24],
+                               pstrb_eff[2] ? CMDOP_PMW[23:16] : cmd_op_reg[23:16],
+                               pstrb_eff[1] ? CMDOP_PMW[15:8] : cmd_op_reg[15:8],
+                               pstrb_eff[0] ? CMDOP_PMW[7:0] : cmd_op_reg[7:0] };
+  wire [31:0] CMDDMY_WDATA = { pstrb_eff[3] ? CMDDMY_PMW[31:24] : cmd_dummy_reg[31:24],
+                               pstrb_eff[2] ? CMDDMY_PMW[23:16] : cmd_dummy_reg[23:16],
+                               pstrb_eff[1] ? CMDDMY_PMW[15:8] : cmd_dummy_reg[15:8],
+                               pstrb_eff[0] ? CMDDMY_PMW[7:0] : cmd_dummy_reg[7:0] };
+  wire [31:0] DMACFG_WDATA = { pstrb_eff[3] ? DMACFG_PMW[31:24] : dma_cfg_reg[31:24],
+                               pstrb_eff[2] ? DMACFG_PMW[23:16] : dma_cfg_reg[23:16],
+                               pstrb_eff[1] ? DMACFG_PMW[15:8] : dma_cfg_reg[15:8],
+                               pstrb_eff[0] ? DMACFG_PMW[7:0] : dma_cfg_reg[7:0] };
+  wire [31:0] CMDADDR_WDATA= { pstrb_eff[3] ? pwdata[31:24] : cmd_addr_reg[31:24],
+                               pstrb_eff[2] ? pwdata[23:16] : cmd_addr_reg[23:16],
+                               pstrb_eff[1] ? pwdata[15:8] : cmd_addr_reg[15:8],
+                               pstrb_eff[0] ? pwdata[7:0] : cmd_addr_reg[7:0] };
+  wire [31:0] CMDLEN_WDATA = { pstrb_eff[3] ? pwdata[31:24] : cmd_len_reg[31:24],
+                               pstrb_eff[2] ? pwdata[23:16] : cmd_len_reg[23:16],
+                               pstrb_eff[1] ? pwdata[15:8] : cmd_len_reg[15:8],
+                               pstrb_eff[0] ? pwdata[7:0] : cmd_len_reg[7:0] };
+  wire [31:0] DMAADDR_WDATA= { pstrb_eff[3] ? pwdata[31:24] : dma_addr_reg[31:24],
+                               pstrb_eff[2] ? pwdata[23:16] : dma_addr_reg[23:16],
+                               pstrb_eff[1] ? pwdata[15:8] : dma_addr_reg[15:8],
+                               pstrb_eff[0] ? pwdata[7:0] : dma_addr_reg[7:0] };
+  wire [31:0] DMALEN_WDATA = { pstrb_eff[3] ? pwdata[31:24] : dma_len_reg[31:24],
+                               pstrb_eff[2] ? pwdata[23:16] : dma_len_reg[23:16],
+                               pstrb_eff[1] ? pwdata[15:8] : dma_len_reg[15:8],
+                               pstrb_eff[0] ? pwdata[7:0] : dma_len_reg[7:0] };
+  // ---------------- CMD_TRIGGER (W1S + CE clear) -----------
+  wire cmd_trig_set = write_phase &
+                      (a == CTRL_ADDR) &
+                      pstrb_eff[1] & // byte1 must be enabled
+                      pwdata[8] & // bit8 set
+                      valid_addr & ~ro_addr; // valid write to CTRL
+  reg cmd_trig_q;
+  always @(posedge pclk or negedge presetn) begin
+    if (!presetn) cmd_trig_q <= 1'b0;
+    else if (cmd_trigger_clr_i) cmd_trig_q <= 1'b0;
+    else if (cmd_trig_set) cmd_trig_q <= 1'b1;
+  end
+  assign cmd_trigger_o = cmd_trig_q;
+  // ---------------- Register writes ------------------------
+  always @(posedge pclk or negedge presetn) begin
+    if (!presetn) begin
+      ctrl_reg <= 32'h0;
+      int_en_reg <= 32'h0;
+      int_stat_reg <= 32'h0;
+      clk_div_reg <= 32'h0;
+      cs_ctrl_reg <= 32'h0000_0001; // auto CS=1 as a friendly default
+      xip_cfg_reg <= 32'h0;
+      xip_cmd_reg <= 32'h0;
+      cmd_cfg_reg <= 32'h0;
+      cmd_op_reg <= 32'h0;
+      cmd_addr_reg <= 32'h0;
+      cmd_len_reg <= 32'h0;
+      cmd_dummy_reg <= 32'h0;
+      dma_cfg_reg <= 32'h0;
+      dma_addr_reg <= 32'h0;
+      dma_len_reg <= 32'h0;
+    end else begin
+      if (wr_ok && (a==CTRL_ADDR)) ctrl_reg <= CTRL_WDATA;
+      // INT_EN write: bits [4:0] are in byte0 -> use pstrb_eff[0] for all
+      if (wr_ok && (a==INT_EN_ADDR)) begin
+        int_en_reg <= {27'd0,
+                       (pstrb_eff[0] ? pwdata[4] : int_en_reg[4]),
+                       (pstrb_eff[0] ? pwdata[3] : int_en_reg[3]),
+                       (pstrb_eff[0] ? pwdata[2] : int_en_reg[2]),
+                       (pstrb_eff[0] ? pwdata[1] : int_en_reg[1]),
+                       (pstrb_eff[0] ? pwdata[0] : int_en_reg[0])};
+      end
+      if (wr_ok && (a==CLK_DIV_ADDR)) clk_div_reg <= CLKDIV_WDATA;
+      if (wr_ok && (a==CS_CTRL_ADDR)) cs_ctrl_reg <= CSCTRL_WDATA;
+      if (wr_ok && (a==XIP_CFG_ADDR)) xip_cfg_reg <= XIPCFG_WDATA;
+      if (wr_ok && (a==XIP_CMD_ADDR)) xip_cmd_reg <= XIPCMD_WDATA;
+      if (wr_ok && (a==CMD_CFG_ADDR)) cmd_cfg_reg <= CMDCFG_WDATA;
+      if (wr_ok && (a==CMD_OP_ADDR)) cmd_op_reg <= CMDOP_WDATA;
+      if (wr_ok && (a==CMD_ADDR_ADDR)) cmd_addr_reg <= CMDADDR_WDATA;
+      if (wr_ok && (a==CMD_LEN_ADDR)) cmd_len_reg <= CMDLEN_WDATA;
+      if (wr_ok && (a==CMD_DUMMY_ADDR)) cmd_dummy_reg <= CMDDMY_WDATA;
+      if (wr_ok && (a==DMA_CFG_ADDR)) dma_cfg_reg <= DMACFG_WDATA;
+      if (wr_ok && (a==DMA_DST_ADDR)) dma_addr_reg <= DMAADDR_WDATA;
+      if (wr_ok && (a==DMA_LEN_ADDR)) dma_len_reg <= DMALEN_WDATA;
+      // INT W1C
+      if (wr_ok && (a==INT_STAT_ADDR)) int_stat_reg <= int_stat_reg & ~pwdata;
+      // INT setters (rising edges below)
+      if (cmd_done_rise) int_stat_reg[0] <= 1'b1;
+      if (dma_done_rise) int_stat_reg[1] <= 1'b1;
+      if (err_rise) int_stat_reg[2] <= 1'b1;
+      if (txe_rise) int_stat_reg[3] <= 1'b1;
+      if (rxf_rise) int_stat_reg[4] <= 1'b1;
+    end
+  end
+  // ---------------- INT edge qualification ----------------
+  reg cmd_done_d, dma_done_d, err_d, txe_d, rxf_d;
+  always @(posedge pclk or negedge presetn) begin
+    if (!presetn) begin
+      cmd_done_d <= 1'b0; dma_done_d <= 1'b0; err_d <= 1'b0; txe_d <= 1'b0; rxf_d <= 1'b0;
+    end else begin
+      cmd_done_d <= cmd_done_set_i;
+      dma_done_d <= dma_done_set_i;
+      err_d <= err_set_i;
+      txe_d <= fifo_tx_empty_set_i;
+      rxf_d <= fifo_rx_full_set_i;
+    end
+  end
+  wire cmd_done_rise = cmd_done_set_i & ~cmd_done_d;
+  wire dma_done_rise = dma_done_set_i & ~dma_done_d;
+  wire err_rise = err_set_i & ~err_d;
+  wire txe_rise = fifo_tx_empty_set_i & ~txe_d;
+  wire rxf_rise = fifo_rx_full_set_i & ~rxf_d;
+  // ---------------- Read mux -------------------------------
+  always @(*) begin
+    prdata = 32'h0; // unmapped reads return 0
+    if (read_phase & valid_addr) begin
+      case (a)
+        ID_ADDR : prdata = id_reg;
+        CTRL_ADDR : prdata = ctrl_reg;
+        STATUS_ADDR : prdata = status_reg;
+        INT_EN_ADDR : prdata = int_en_reg;
+        INT_STAT_ADDR : prdata = int_stat_reg;
+        CLK_DIV_ADDR : prdata = clk_div_reg;
+        CS_CTRL_ADDR : prdata = cs_ctrl_reg;
+        XIP_CFG_ADDR : prdata = xip_cfg_reg;
+        XIP_CMD_ADDR : prdata = xip_cmd_reg;
+        CMD_CFG_ADDR : prdata = cmd_cfg_reg;
+        CMD_OP_ADDR : prdata = cmd_op_reg;
+        CMD_ADDR_ADDR : prdata = cmd_addr_reg;
+        CMD_LEN_ADDR : prdata = cmd_len_reg;
+        CMD_DUMMY_ADDR: prdata = cmd_dummy_reg;
+        DMA_CFG_ADDR : prdata = dma_cfg_reg;
+        DMA_DST_ADDR : prdata = dma_addr_reg;
+        DMA_LEN_ADDR : prdata = dma_len_reg;
+        FIFO_STAT_ADDR: prdata = fifo_stat_reg;
+        ERR_STAT_ADDR : prdata = err_stat_reg;
+        FIFO_RX_ADDR : prdata = fifo_rx_data_i;
+        default : prdata = 32'h0;
+      endcase
+    end
+  end
+  // ---------------- Field mapping --------------------------
+  // CTRL (bit8 is trigger only; not stored as '1' in ctrl_reg)
+  assign enable_o = ctrl_reg[0];
+  assign xip_en_o = ctrl_reg[1];
+  assign quad_en_o = ctrl_reg[2];
+  assign cpol_o = ctrl_reg[3];
+  assign cpha_o = ctrl_reg[4];
+  assign lsb_first_o = ctrl_reg[5];
+  assign dma_en_o = ctrl_reg[6];
+  assign mode_en_o = ctrl_reg[7];
+  // bit[8] is trigger pulse only (see cmd_trigger_o)
+  assign hold_en_o = ctrl_reg[9];
+  assign wp_en_o = (HAS_WP!=0) ? ctrl_reg[10] : 1'b0;
+  // Clock & CS
+  assign clk_div_o = clk_div_reg[2:0];
+  assign cs_auto_o = cs_ctrl_reg[0];
+  assign cs_level_o = cs_ctrl_reg[2:1];
+  assign cs_delay_o = cs_ctrl_reg[4:3];
+  // XIP
+  assign xip_addr_bytes_o = xip_cfg_reg[1:0];
+  assign xip_data_lanes_o = xip_cfg_reg[3:2];
+  assign xip_dummy_cycles_o = xip_cfg_reg[7:4];
+  assign xip_cont_read_o = xip_cfg_reg[8];
+  assign xip_mode_en_o = xip_cfg_reg[9];
+  assign xip_write_en_o = xip_cfg_reg[10];
+  assign xip_read_op_o = xip_cmd_reg[7:0];
+  assign xip_write_op_o = xip_cmd_reg[15:8];
+  assign xip_mode_bits_o = xip_cmd_reg[23:16];
+  // Command mode
+  assign cmd_lanes_o = cmd_cfg_reg[1:0];
+  assign addr_lanes_o = cmd_cfg_reg[3:2];
+  assign data_lanes_o = cmd_cfg_reg[5:4];
+  assign addr_bytes_o = cmd_cfg_reg[7:6];
+  assign mode_en_cfg_o = mode_en_o; // tied to CTRL.mode_en
+  assign dummy_cycles_o = cmd_cfg_reg[11:8];
+  assign is_write_o = cmd_cfg_reg[12];
+  assign opcode_o = cmd_op_reg[7:0];
+  assign mode_bits_o = cmd_op_reg[15:8];
+  assign cmd_addr_o = cmd_addr_reg;
+  assign cmd_len_o = cmd_len_reg;
+  assign extra_dummy_o = cmd_dummy_reg[7:0];
+  // DMA
+  assign burst_size_o = dma_cfg_reg[3:0];
+  assign dma_dir_o = dma_cfg_reg[4];
+  assign incr_addr_o = dma_cfg_reg[5];
+  assign dma_addr_o = dma_addr_reg;
+  assign dma_len_o = dma_len_reg;
+  // INT
+  assign int_en_o = int_en_reg[4:0];
+  assign irq = |(int_en_reg[4:0] & int_stat_reg[4:0]);
+endmodule

--- a/rtl/fifo.v
+++ b/rtl/fifo.v
@@ -1,0 +1,43 @@
+module fifo (
+    input wire clk,
+    input wire rst_n,
+    input wire wr_en,        // Write enable signal
+    input wire [31:0] data_in,  // Data to be written
+    output reg full,         // Full flag
+    input wire rd_en,        // Read enable signal
+    output reg [31:0] data_out, // Data read from FIFO
+    output reg empty         // Empty flag
+);
+
+    // FIFO storage
+    reg [31:0] mem [0:255];  // FIFO size: 256 entries (32-bit words)
+    reg [7:0] write_ptr;     // Write pointer
+    reg [7:0] read_ptr;      // Read pointer
+
+    // FIFO write operation
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            write_ptr <= 8'd0;
+            read_ptr  <= 8'd0;
+            full      <= 1'b0;
+            empty     <= 1'b1;
+            data_out  <= 32'd0;
+        end else begin
+            // Write operation
+            if (wr_en && !full) begin
+                mem[write_ptr] <= data_in;
+                write_ptr <= write_ptr + 1;
+            end
+
+            // Read operation
+            if (rd_en && !empty) begin
+                data_out <= mem[read_ptr];
+                read_ptr  <= read_ptr + 1;
+            end
+
+            // Update full and empty flags
+            full  <= (write_ptr == (read_ptr - 1)) ? 1'b1 : 1'b0;
+            empty <= (write_ptr == read_ptr) ? 1'b1 : 1'b0;
+        end
+    end
+endmodule

--- a/rtl/qspi_device.v
+++ b/rtl/qspi_device.v
@@ -1,0 +1,287 @@
+module qspi_device (
+    input wire qspi_sclk,
+    input wire qspi_cs_n,
+    inout wire qspi_io0,
+    inout wire qspi_io1,
+    inout wire qspi_io2,
+    inout wire qspi_io3
+);
+
+    parameter MEM_SIZE 	  = 1024 * 1024;
+    parameter ADDR_BITS   = 24;
+    parameter PAGE_SIZE   = 256;
+    parameter SECTOR_SIZE = 4096;
+    parameter ERASE_TIME  = 100;
+
+    reg [7:0] memory [0:MEM_SIZE-1];
+
+    reg [3:0] io_oe  = 0;
+    reg [3:0] io_do  = 0;
+    wire [3:0] io_di = {qspi_io3, qspi_io2, qspi_io1, qspi_io0};
+
+    assign qspi_io0 = io_oe[0] ? io_do[0] : 1'bz;
+    assign qspi_io1 = io_oe[1] ? io_do[1] : 1'bz;
+    assign qspi_io2 = io_oe[2] ? io_do[2] : 1'bz;
+    assign qspi_io3 = io_oe[3] ? io_do[3] : 1'bz;
+
+    reg [7:0] 		status_reg 	 = 8'h00;
+    reg [31:0] 		id_reg 		 = 32'h00C22017;
+    reg [7:0] 		cmd_reg 	 = 0;
+    reg [7:0] 		nxt_cmd_reg 	 = 0;
+    reg [ADDR_BITS-1:0] addr_reg 	 = 0;
+    reg [7:0] 		mode_bits 	 = 0;
+    reg [7:0]		shift_in 	 = 0;
+    reg [7:0]		shift_out 	 = 0;
+    reg [3:0]		lanes 		 = 0;
+    reg [4:0]		dummy_cycles 	 = 0;
+    reg			continuous_read = 0;
+
+    localparam ST_IDLE 		= 4'h0;
+    localparam ST_CMD 		= 4'h1;
+    localparam ST_ADDR 		= 4'h2;
+    localparam ST_MODE 		= 4'h3;
+    localparam ST_DUMMY 	= 4'h4;
+    localparam ST_DATA_READ 	= 4'h5;
+    localparam ST_DATA_WRITE 	= 4'h6;
+    localparam ST_ERASE 	= 4'h7;
+    localparam ST_STATUS 	= 4'h8;
+    localparam ST_ID_READ 	= 4'h9;
+    reg [3:0] state = ST_IDLE;
+
+    reg [31:0] 	bit_cnt 	= 0;
+    reg [31:0] 	nxt_bit_cnt 	= 0;
+    reg [31:0] 	nxt_addr_reg 	= 0;
+    reg [31:0] 	byte_cnt 	= 0;
+    reg 	wip 		= 0;
+    reg [31:0] 	erase_counter 	= 0;
+
+
+    initial begin
+    	integer i;
+    	for (i = 0; i < MEM_SIZE; i = i + 1) begin
+            memory[i] = 8'hFF;
+    	end
+    end
+
+    always @(posedge qspi_sclk) begin
+    	if (wip)
+            erase_counter <= erase_counter + 1;
+
+    	if (erase_counter >= ERASE_TIME) begin
+            wip <= 0;
+            erase_counter <= 0;
+    	end
+    end
+
+    always @(posedge qspi_sclk or posedge qspi_cs_n) begin
+        if (qspi_cs_n) begin
+            state <= ST_IDLE;
+            io_oe <= 4'b0000;
+            continuous_read <= 0;
+            shift_in <= 0;
+    	end else begin
+            case (state)
+            	ST_IDLE: begin
+                      	state <= ST_CMD;
+                	bit_cnt <= 0;
+                	lanes <= 1;
+                	shift_in <= {shift_in[6:0], io_di[0]};
+                end
+
+                ST_CMD: begin
+                	shift_in <= {shift_in[6:0], io_di[0]};
+                	bit_cnt <= bit_cnt + 1;
+                	if (nxt_bit_cnt == 7) begin
+                    	    cmd_reg <= {shift_in[6:0], io_di[0]};
+			    bit_cnt <= 0;
+			    byte_cnt <= 0;
+			    case (nxt_cmd_reg)
+				8'h9F: begin
+        				state <= ST_ID_READ;
+        				lanes <= 1;
+        				dummy_cycles <= 0;
+        				shift_out <= id_reg[23:16];
+        				io_oe <= 4'b0010;
+    				end
+    				8'h05: begin
+        				state <= ST_STATUS;
+        				lanes <= 1;
+        				shift_out <= status_reg;
+        				io_oe <= 4'b0010;
+    				end
+    				8'h06: begin
+        				status_reg[1] <= 1;
+        				state <= ST_IDLE;
+    				end
+    				8'h04: begin
+        				status_reg[1] <= 0;
+        				state <= ST_IDLE;
+    				end
+    				8'h03, 8'h0B, 8'h3B, 8'h6B, 8'hEB: begin
+        				state <= ST_ADDR;
+        				addr_reg <= 0;
+        				shift_in <= 0;
+        				lanes <= (nxt_cmd_reg == 8'h03 || nxt_cmd_reg == 8'h0B) ? 1 : (nxt_cmd_reg == 8'h3B) ? 2 : 4;
+        				dummy_cycles <= (nxt_cmd_reg == 8'h03) ? 0 : (nxt_cmd_reg == 8'hEB) ? 6 : 8;
+    				end
+    				8'h02, 8'h32: begin
+        				dummy_cycles <= 0;
+        				if (status_reg[1]) begin
+            				    state <= ST_ADDR;
+            				    lanes <= (nxt_cmd_reg == 8'h02) ? 1 : 4;
+        				end else state <= ST_IDLE;
+    				end
+    				8'h20, 8'hD8: begin
+					if (status_reg[1]) begin
+					    state <= ST_ADDR;
+					end else state <= ST_IDLE;
+				end
+				8'hC7: begin
+        				if (status_reg[1]) begin
+            				    integer j;
+            				    for (j = 0; j < MEM_SIZE; j = j + 1) memory[j] <= 8'hFF;
+            				    state <= ST_ERASE;
+            				    wip <= 1;
+        				end else state <= ST_IDLE;
+    				end
+    				default: state <= ST_IDLE;
+			    endcase
+			end
+		end
+
+                ST_ADDR: begin
+                	if (lanes == 1) shift_in <= {shift_in[6:0], io_di[0]};
+                	else if (lanes == 2) shift_in <= {shift_in[5:0], io_di[1:0]};
+                	else if (lanes == 4) shift_in <= {shift_in[3:0], io_di[3:0]};
+                	bit_cnt <= bit_cnt + lanes;
+                	if ((bit_cnt == 7 && lanes == 1) || (bit_cnt == 6 && lanes == 2) || (bit_cnt == 4 && lanes == 4)) begin
+                    		addr_reg <= {addr_reg[ADDR_BITS-9:0], lanes == 1 ? {shift_in[6:0], io_di[0]} : lanes == 2 ? {shift_in[5:0], io_di[1:0]} : {shift_in[3:0], io_di[3:0]}};
+    				bit_cnt <= 0; // reset shifter
+    				shift_in <= 0; // reset shifter
+    				byte_cnt <= byte_cnt + 1; // Increment first to avoid error
+    				if (byte_cnt == (ADDR_BITS/8) - 1) begin // if last byte of address then state transition
+        				if (cmd_reg == 8'hEB) state <= ST_MODE;
+        				else if (cmd_reg == 8'h20 | cmd_reg == 8'hD8) begin // need to take care of erase here since CS deassert next cycle
+            					integer j;
+            					if (cmd_reg == 8'h20) begin
+                					for (j = nxt_addr_reg; j < nxt_addr_reg + SECTOR_SIZE; j = j + 1) memory[j] <= 8'hFF;
+            					end else if (cmd_reg == 8'hD8) begin
+                					for (j = nxt_addr_reg; j < nxt_addr_reg + 65536; j = j + 1) memory[j] <= 8'hFF;
+            					end
+            					wip <= 1;
+            					state <= ST_ERASE;
+        				end else if (dummy_cycles > 0) state <= ST_DUMMY;
+            				else begin
+                				state <= (cmd_reg == 8'h02 || cmd_reg == 8'h32 ? ST_DATA_WRITE : ST_DATA_READ);
+                				bit_cnt <= 0;
+                				byte_cnt <= 0;
+                				if (cmd_reg == 8'h02 || cmd_reg == 8'h32) io_oe <= 4'b0000;
+                				else if (lanes == 1) io_oe <= 4'b0010;
+                				else if (lanes == 2) io_oe <= 4'b0011;
+                				else io_oe <= 4'b1111;
+                				shift_out <= memory[addr_reg];
+            				end
+        			end
+    			end
+		end
+
+            	ST_MODE: begin
+                	if (lanes == 1) shift_in <= {shift_in[6:0], io_di[0]};
+                	else if (lanes == 2) shift_in <= {shift_in[5:0], io_di[1:0]};
+                	else if (lanes == 4) shift_in <= {shift_in[3:0], io_di[3:0]};
+                	bit_cnt <= bit_cnt + lanes;
+                	if (bit_cnt == 8) begin
+                    	    mode_bits <= shift_in[7:0];
+                    	    continuous_read <= (shift_in == 8'hA0);
+                    	    state <= ST_DUMMY;
+			    bit_cnt <= 0;
+                	end
+            	end
+
+            	ST_DUMMY: begin
+                	bit_cnt <= bit_cnt + 1;
+                	if (bit_cnt == (dummy_cycles - 1)) begin
+                    	    state <= (cmd_reg == 8'h02 || cmd_reg == 8'h32 ? ST_DATA_WRITE : ST_DATA_READ);
+                    	    bit_cnt <= 0;
+                    	    byte_cnt <= 0;
+                    	    if (cmd_reg == 8'h02 || cmd_reg == 8'h32) io_oe <= 4'b0000;
+                    	    else if (lanes == 1) io_oe <= 4'b0010;
+                    	    else if (lanes == 2) io_oe <= 4'b0011;
+                    	    else io_oe <= 4'b1111;
+                    	    shift_out <= memory[addr_reg];
+                	end
+            	end
+
+            	ST_DATA_READ: begin
+                	if (lanes == 1) io_do[1] <= shift_out[7];
+                	else if (lanes == 2) begin
+                    		io_do[0] <= shift_out[6];
+                    		io_do[1] <= shift_out[7];
+                	end else if (lanes == 4) begin
+                    		io_do[0] <= shift_out[4];
+                    		io_do[1] <= shift_out[5];
+                    		io_do[2] <= shift_out[6];
+                    		io_do[3] <= shift_out[7];
+                	end
+                	shift_out <= shift_out << lanes;
+                	bit_cnt <= bit_cnt + lanes;
+                	if ((bit_cnt == 7 && lanes == 1) || (bit_cnt == 6 && lanes == 2) || (bit_cnt == 4 && lanes == 4)) begin
+                    	    addr_reg <= addr_reg + 1;
+                    	    shift_out <= memory[addr_reg + 1];
+                    	    bit_cnt <= 0;
+                	end
+                        if (!continuous_read && byte_cnt == MEM_SIZE - addr_reg)
+                            state <= ST_IDLE;
+                        byte_cnt <= byte_cnt + 1;
+                end
+
+            	ST_DATA_WRITE: begin
+                	if (lanes == 1) shift_in <= {shift_in[6:0], io_di[0]};
+                	else if (lanes == 2) shift_in <= {shift_in[5:0], io_di[1:0]};
+                	else if (lanes == 4) shift_in <= {shift_in[3:0], io_di[3:0]};
+                	bit_cnt <= bit_cnt + lanes;
+                        if ((bit_cnt == 7 && lanes == 1) || (bit_cnt == 6 && lanes == 2) || (bit_cnt == 4 && lanes == 4)) begin
+                            if (addr_reg <= MEM_SIZE && (addr_reg % PAGE_SIZE != PAGE_SIZE - 1)) begin
+                                memory[addr_reg] <= (lanes == 1) ? {shift_in[6:0], io_di[0]} :
+                                                   (lanes == 2) ? {shift_in[5:0], io_di[1:0]} :
+                                                                  {shift_in[3:0], io_di[3:0]};
+                                addr_reg <= addr_reg + 1;
+                            end
+                            bit_cnt <= 0;
+                            byte_cnt <= byte_cnt + 1;
+                            wip <= 1;
+                        end
+            	end
+
+            	ST_ERASE: begin
+                	// device won't stay full cycle here since CS# will be de-asserted
+                	state <= ST_IDLE;
+            	end
+
+            	ST_STATUS: begin
+                	io_do[1] <= shift_out[7];
+                	shift_out <= shift_out << 1;
+                	bit_cnt <= bit_cnt + 1;
+                	if (bit_cnt == 8) state <= ST_IDLE;
+            	end
+
+            	ST_ID_READ: begin // do only manufacturing id
+                	io_do[1] <= shift_out[7];
+                	shift_out <= shift_out << 1;
+                	bit_cnt <= bit_cnt + 1;
+                	if (bit_cnt == 8) state <= ST_IDLE;
+            	end
+
+            	default: state <= ST_IDLE;
+            endcase
+    	end
+    end
+
+    always @* begin
+    	status_reg[0] = wip;
+    	nxt_cmd_reg = {shift_in[6:0], io_di[0]};
+    	nxt_bit_cnt = bit_cnt + 1;
+    	nxt_addr_reg = {addr_reg[ADDR_BITS-9:0], lanes == 1 ? {shift_in[6:0], io_di[0]} : lanes == 2 ? {shift_in[5:0], io_di[1:0]} : {shift_in[3:0], io_di[3:0]}};
+	end
+
+endmodule

--- a/rtl/qspi_fsm.v
+++ b/rtl/qspi_fsm.v
@@ -1,0 +1,359 @@
+module qspi_fsm #(
+    parameter ADDR_WIDTH = 32
+)(
+    input wire clk,
+    input wire resetn,
+
+    // Kick start & done
+    input wire start,   // pulse to start a transaction
+    output wire done,
+
+    // CMD_CFG
+    input wire [1:0] cmd_lanes_sel,  // 0:1bit,1:2bit,2:4bit (CMD LANES)
+    input wire [1:0] addr_lanes_sel, // 0:1bit,1:2bit,2:4bit (ADDR LANES)
+    input wire [1:0] data_lanes_sel, // 0:1bit,1:2bit,2:4bit (DATA LANES)
+    input wire [1:0] addr_bytes_sel, // 0:0B, 1:3B, 2:4B
+    input wire mode_en,              // MODE EN
+    input wire [3:0] dummy_cycles,   // Number of dummy clock cycles
+    input wire dir,                  // 0:Write(Tx) -1:Read(Rx) (DIR)
+
+    // CMD_OP
+    input wire [7:0] cmd_opcode,
+    input wire [7:0] mode_bits,
+
+    // CMD_ADDR
+    input wire [ADDR_WIDTH-1:0] addr,
+
+    // CMD_LEN
+    input wire [31:0] len_bytes,
+
+    // CTRL bits for SPI clocking
+    input wire [31:0] clk_div,
+
+    // CPOL and CPHA
+    input wire cpol,
+    input wire cpha,
+
+    // Write path (DIR=0)
+    input wire [31:0] tx_data_fifo,
+    output wire tx_ren,
+    output wire tx_empty,
+
+    // Read path (DIR=1)
+    output reg [31:0] rx_data_fifo,
+    output reg rx_wen,
+    input wire rx_full,
+
+    // QSPI Pins
+    output wire sclk,
+    output reg cs_n,
+    inout wire io0,
+    inout wire io1,
+    inout wire io2,
+    inout wire io3
+);
+
+// CMD OPCODE
+// Read
+localparam READ       = 8'h03; // Read Data Bytes
+localparam FAST_READ  = 8'h0B; // Read Data Bytes at Higher Speed
+localparam READ_2     = 8'hBB; // 2 x I/O Read Mode
+localparam QREAD      = 8'h6B; // Quad I/O Read Mode
+localparam READ_4     = 8'hEB; // 4 x I/O Read Mode
+
+// Write
+localparam SE         = 8'h20; // Sector Erase
+localparam BE         = 8'hD8; // Block Erase
+localparam CE         = 8'h60; // Chip Erase
+localparam PP         = 8'h02; // Page Program
+localparam PP_4       = 8'h38; // 4 x I/O Page Program
+localparam WREN       = 8'h06; // Write Enable
+
+// State Machine
+localparam IDLE       = 4'd0,
+           CS         = 4'd1,
+           CMD        = 4'd2,
+           ADDR       = 4'd3,
+           MODE       = 4'd4,
+           DUMMY      = 4'd5,
+           DATA       = 4'd6,
+           STOP_CS    = 4'd7;
+
+    reg [3:0] state, next_state;
+    reg [31:0] bit_cnt, next_bit_cnt;
+    reg [31:0] byte_cnt, next_byte_cnt;
+    reg [3:0]  lanes, next_lanes;
+    reg [31:0] data_shift_reg, next_data_shift_reg;
+    reg [3:0]  io_oe, next_io_oe;
+    reg [3:0]  dummy_left, next_dummy_left;
+
+    integer cmd_lanes_eff, addr_lanes_eff, data_lanes_eff;
+    integer addr_bits;
+
+    // SCLK engine
+    reg        sclk_en, next_sclk_en;
+    reg [31:0] sclk_cnt;
+    reg        sclk_q;
+    reg        sclk_edge;
+    reg        sclk_phase;
+
+    // QSPI I/O
+    wire [3:0] io_di = {io3, io2, io1, io0};
+    reg  [3:0] out_bits;
+    reg  [3:0] input_bits;
+
+    // CPHA/CPOL edge decode
+    wire shift_pulse  = sclk_edge & (cpha ? (sclk_phase==1'b0) : (sclk_phase==1'b1));
+    wire sample_pulse = sclk_edge & ~shift_pulse;
+    wire bit_tick     = sample_pulse;
+
+    // Done
+    assign done = (state == STOP_CS);
+
+    // Tri-state mapping
+    assign io3 = io_oe[3] ? out_bits[3] : 1'bz;
+    assign io2 = io_oe[2] ? out_bits[2] : 1'bz;
+    assign io1 = io_oe[1] ? out_bits[1] : 1'bz;
+    assign io0 = io_oe[0] ? out_bits[0] : 1'bz;
+
+    // Output bit mux
+    always @* begin
+        case (lanes)
+            1: out_bits = {3'b000, data_shift_reg[31]};
+            2: out_bits = {2'b00, data_shift_reg[31], data_shift_reg[30]};
+            4: out_bits = {data_shift_reg[31], data_shift_reg[30], data_shift_reg[29], data_shift_reg[28]};
+            default: out_bits = 4'b0000;
+        endcase
+        case (lanes)
+            1: input_bits = {3'b000, io_di[1]};
+            2: input_bits = {2'b00, io_di[1:0]};
+            4: input_bits = io_di[3:0];
+            default: input_bits = 4'b0000;
+        endcase
+    end
+
+    // SCLK output
+    assign sclk = sclk_en ? sclk_q : cpol;
+
+    // SCLK generator
+    always @(posedge clk or negedge resetn) begin
+        if (!resetn) begin
+            sclk_cnt   <= 0;
+            sclk_q     <= cpol;
+            sclk_edge  <= 1'b0;
+            sclk_phase <= 1'b0;
+        end else begin
+            sclk_edge <= 1'b0;
+            if (!sclk_en) begin
+                sclk_cnt   <= 0;
+                sclk_q     <= cpol;
+                sclk_phase <= 1'b0;
+            end else begin
+                if (sclk_cnt >= clk_div) begin
+                    sclk_cnt   <= 0;
+                    sclk_q     <= ~sclk_q;
+                    sclk_edge  <= 1'b1;
+                    sclk_phase <= ~sclk_phase;
+                end else begin
+                    sclk_cnt <= sclk_cnt + 1;
+                end
+            end
+        end
+    end
+
+    // Sequential state registers
+    always @(posedge clk or negedge resetn) begin
+        if (!resetn) begin
+            state <= IDLE;
+            cs_n  <= 1'b1;
+            bit_cnt <= 0;
+            byte_cnt <= 0;
+            lanes <= 1;
+            data_shift_reg <= 0;
+            io_oe <= 0;
+              sclk_en <= 0;
+              dummy_left <= 0;
+        end else begin
+            state <= next_state;
+            cs_n  <= (next_state==IDLE || next_state==STOP_CS);
+            bit_cnt <= next_bit_cnt;
+            byte_cnt <= next_byte_cnt;
+            lanes <= next_lanes;
+            data_shift_reg <= next_data_shift_reg;
+            io_oe <= next_io_oe;
+            sclk_en <= next_sclk_en;
+            dummy_left <= next_dummy_left;
+        end
+    end
+
+    // FSM
+    always @* begin
+        // defaults
+        next_state = state;
+        next_bit_cnt = bit_cnt;
+        next_byte_cnt = byte_cnt;
+        next_lanes = lanes;
+        next_data_shift_reg = data_shift_reg;
+        next_io_oe = io_oe;
+        next_sclk_en = 1'b0;
+        next_dummy_left = dummy_left;
+        rx_wen = 1'b0;
+        rx_data_fifo = 32'b0;
+
+        // lane decode
+        cmd_lanes_eff  = (cmd_lanes_sel==2'b00)?1:(cmd_lanes_sel==2'b01)?2:4;
+        addr_lanes_eff = (addr_lanes_sel==2'b00)?1:(addr_lanes_sel==2'b01)?2:4;
+        data_lanes_eff = (data_lanes_sel==2'b00)?1:(data_lanes_sel==2'b01)?2:4;
+
+        case (state)
+            IDLE: begin
+                if (start) next_state = CS;
+            end
+
+            CS: begin
+                next_state = CMD;
+                next_bit_cnt = 0;
+                next_lanes = cmd_lanes_eff;
+                next_data_shift_reg = {24'b0, cmd_opcode};
+                next_io_oe = (next_lanes==1)?4'b0001:(next_lanes==2)?4'b0011:4'b1111;
+            end
+
+            CMD: begin
+                next_sclk_en = 1;
+                if (shift_pulse) next_data_shift_reg = data_shift_reg << lanes;
+                if (bit_tick) begin
+                    next_bit_cnt = bit_cnt + lanes;
+                    if (next_bit_cnt >= 8) begin
+                        next_bit_cnt = 0;
+                        case (cmd_opcode)
+                            READ, FAST_READ, READ_2, QREAD, READ_4, PP, PP_4: next_state = ADDR;
+                            SE, BE: next_state = ADDR;
+                            CE, WREN: next_state = STOP_CS;
+                            default: next_state = STOP_CS;
+                        endcase
+                        if (next_state==ADDR) begin
+                            next_lanes = addr_lanes_eff;
+                            next_data_shift_reg = (addr_bytes_sel==2'b01)?{8'b0,addr[23:0]}:addr;
+                            next_io_oe = (next_lanes==1)?4'b0001:(next_lanes==2)?4'b0011:4'b1111;
+                        end
+                    end
+                end
+            end
+
+            ADDR: begin
+                next_sclk_en = 1;
+                if (shift_pulse) next_data_shift_reg = data_shift_reg << lanes;
+                  addr_bits = (addr_bytes_sel==2'b01)?24:32;
+                if (bit_tick) begin
+                    next_bit_cnt = bit_cnt + lanes;
+                    if (next_bit_cnt >= addr_bits) begin
+                        next_bit_cnt = 0;
+                        case (cmd_opcode)
+                            READ, FAST_READ, READ_2, QREAD, READ_4: begin
+                                if (mode_en && (cmd_opcode==READ_2 || cmd_opcode==READ_4)) begin
+                                    next_state = MODE;
+                                    next_lanes = data_lanes_eff;
+                                    next_data_shift_reg = {24'b0, mode_bits};
+                                end else if (dummy_cycles!=0 || cmd_opcode!=READ) begin
+                                    next_state = DUMMY;
+                                    next_dummy_left = dummy_cycles;
+                                end else begin
+                                    next_state = DATA;
+                                    next_lanes = data_lanes_eff;
+                                    next_io_oe = dir?4'b0000:((next_lanes==1)?4'b0001:(next_lanes==2)?4'b0011:4'b1111);
+                                    next_data_shift_reg = dir?32'b0:tx_data_fifo;
+                                    next_byte_cnt = 0;
+                                end
+                            end
+                            PP, PP_4: begin
+                                next_state = DATA;
+                                next_lanes = data_lanes_eff;
+                                next_io_oe = (next_lanes==1)?4'b0001:(next_lanes==2)?4'b0011:4'b1111;
+                                next_data_shift_reg = tx_data_fifo;
+                                next_byte_cnt = 0;
+                            end
+                            SE, BE: next_state = STOP_CS;
+                        endcase
+                    end
+                end
+            end
+
+            MODE: begin
+                next_sclk_en = 1;
+                if (shift_pulse) next_data_shift_reg = data_shift_reg << lanes;
+                if (bit_tick) begin
+                    next_bit_cnt = bit_cnt + lanes;
+                    if (next_bit_cnt >= 8) begin
+                        next_bit_cnt = 0;
+                        if (dummy_cycles!=0) begin
+                            next_state = DUMMY;
+                            next_dummy_left = dummy_cycles;
+                        end else begin
+                            next_state = DATA;
+                            next_lanes = data_lanes_eff;
+                            next_io_oe = dir?4'b0000:((next_lanes==1)?4'b0001:(next_lanes==2)?4'b0011:4'b1111);
+                            next_data_shift_reg = dir?32'b0:tx_data_fifo;
+                            next_byte_cnt = 0;
+                        end
+                    end
+                end
+            end
+
+            DUMMY: begin
+                next_sclk_en = 1;
+                next_io_oe = 0;
+                if (bit_tick) begin
+                    if (dummy_left>0) next_dummy_left = dummy_left - 1;
+                    if (dummy_left==1) begin
+                        next_state = DATA;
+                        next_lanes = data_lanes_eff;
+                        next_io_oe = dir?4'b0000:((next_lanes==1)?4'b0001:(next_lanes==2)?4'b0011:4'b1111);
+                        next_data_shift_reg = dir?32'b0:tx_data_fifo;
+                        next_byte_cnt = 0;
+                    end
+                end
+            end
+
+            DATA: begin
+                next_sclk_en = 1;
+                if (dir) begin
+                    if (sample_pulse) next_data_shift_reg = (data_shift_reg<<lanes)|input_bits;
+                    if (bit_tick) begin
+                        next_bit_cnt = bit_cnt + lanes;
+                        if (next_bit_cnt >= 32) begin
+                            if (!rx_full) begin
+                                rx_data_fifo = data_shift_reg;
+                                rx_wen = 1;
+                            end
+                            next_data_shift_reg = 0;
+                            next_byte_cnt = byte_cnt + 4;
+                            next_bit_cnt = 0;
+                        end
+                        if (byte_cnt+4 >= len_bytes) next_state = STOP_CS;
+                    end
+                end else begin
+                    if (shift_pulse) next_data_shift_reg = data_shift_reg<<lanes;
+                    if (bit_tick) begin
+                        next_bit_cnt = bit_cnt + lanes;
+                        if (next_bit_cnt >= 32) begin
+                            next_data_shift_reg = tx_data_fifo;
+                            next_byte_cnt = byte_cnt + 4;
+                            next_bit_cnt = 0;
+                        end
+                        if (byte_cnt+4 >= len_bytes) next_state = STOP_CS;
+                    end
+                end
+            end
+
+            STOP_CS: begin
+                next_io_oe = 0;
+                next_sclk_en = 0;
+                next_state = IDLE;
+            end
+        endcase
+    end
+
+    // tx_ren: request FIFO word
+    assign tx_ren = (state==DATA) & (~dir) & (bit_cnt+lanes>=32) & (byte_cnt<len_bytes) & ~tx_empty;
+
+endmodule


### PR DESCRIPTION
## Summary
- convert design documents into synthesizable Verilog modules
- provide top-level CSR, FSM, FIFO and AXI helper blocks along with a flash model
- document build steps and module overview in README

## Testing
- `verilator --lint-only -Wno-fatal rtl/axi_read_block.v rtl/axi_write_block.v rtl/csr.v rtl/fifo.v rtl/qspi_fsm.v`
- `iverilog -g2012 -s qspi_fsm -o /tmp/qspi_fsm.vvp rtl/axi_read_block.v rtl/axi_write_block.v rtl/csr.v rtl/fifo.v rtl/qspi_fsm.v`
- `iverilog -g2012 -s qspi_device -o /tmp/qspi_device.vvp rtl/qspi_device.v`
