### PR TITLE
Add basic testbenches for RTL modules

### DIFF
--- a/tb/axi_read_block_tb.v
+++ b/tb/axi_read_block_tb.v
@@ -1,0 +1,87 @@
+`timescale 1ns/1ps
+
+module axi_read_block_tb;
+    reg clk;
+    reg rst_n;
+    reg start;
+    reg [31:0] addr;
+    reg [15:0] transfer_size;
+    wire [31:0] araddr;
+    wire arvalid;
+    reg arready;
+    reg rvalid;
+    reg [31:0] rdata;
+    wire rready;
+    wire [31:0] data_out;
+    wire wr_en;
+    reg full;
+    wire busy;
+    wire done;
+
+    axi_read_block dut (
+        .clk(clk),
+        .rst_n(rst_n),
+        .start(start),
+        .addr(addr),
+        .transfer_size(transfer_size),
+        .araddr(araddr),
+        .arvalid(arvalid),
+        .arready(arready),
+        .rvalid(rvalid),
+        .rdata(rdata),
+        .rready(rready),
+        .data_out(data_out),
+        .wr_en(wr_en),
+        .full(full),
+        .busy(busy),
+        .done(done)
+    );
+
+    integer count;
+
+    initial clk = 0;
+    always #5 clk = ~clk;
+
+    initial begin
+        clk = 0;
+        rst_n = 0;
+        start = 0;
+        addr = 0;
+        transfer_size = 16'd8;
+        arready = 0;
+        rvalid = 0;
+        rdata = 0;
+        full = 0;
+        count = 0;
+        #20 rst_n = 1;
+        @(posedge clk);
+        start <= 1;
+        @(posedge clk);
+        start <= 0;
+    end
+
+    always @(posedge clk) begin
+        if (arvalid) begin
+            arready <= 1;
+            rdata <= araddr;
+            rvalid <= 1;
+        end else begin
+            arready <= 0;
+            if (rready && rvalid)
+                rvalid <= 0;
+        end
+
+        if (wr_en) begin
+            if (data_out !== (addr + count * 4)) begin
+                $fatal(1, "Unexpected data %h", data_out);
+            end
+            count <= count + 1;
+        end
+
+        if (done) begin
+            if (count != 2) $fatal(1, "Wrong word count");
+            $display("AXI read block test passed");
+            $finish;
+        end
+    end
+endmodule

--- a/tb/axi_write_block_tb.v
+++ b/tb/axi_write_block_tb.v
@@ -1,0 +1,91 @@
+`timescale 1ns/1ps
+
+module axi_write_block_tb;
+    reg clk;
+    reg rst_n;
+    reg start;
+    reg [31:0] addr;
+    reg [15:0] transfer_size;
+    wire [31:0] awaddr;
+    wire awvalid;
+    reg awready;
+    wire [31:0] wdata;
+    wire wvalid;
+    wire [3:0] wstrb;
+    reg wready;
+    reg bvalid;
+    wire bready;
+    reg [31:0] data_in;
+    reg empty;
+    wire rd_en;
+    wire busy;
+    wire done;
+
+    axi_write_block dut (
+        .clk(clk),
+        .rst_n(rst_n),
+        .start(start),
+        .addr(addr),
+        .transfer_size(transfer_size),
+        .awaddr(awaddr),
+        .awvalid(awvalid),
+        .awready(awready),
+        .wdata(wdata),
+        .wvalid(wvalid),
+        .wstrb(wstrb),
+        .wready(wready),
+        .bvalid(bvalid),
+        .bready(bready),
+        .data_in(data_in),
+        .empty(empty),
+        .rd_en(rd_en),
+        .busy(busy),
+        .done(done)
+    );
+
+    reg [31:0] fifo_mem [0:1];
+    reg [31:0] captured [0:1];
+    integer idx;
+    integer write_cnt;
+
+    initial clk = 0;
+    always #5 clk = ~clk;
+
+    initial begin
+        rst_n = 0;
+        start = 0;
+        addr = 0;
+        transfer_size = 16'd8;
+        awready = 1;
+        wready = 1;
+        bvalid = 1;
+        data_in = 0;
+        empty = 0;
+        idx = 0;
+        write_cnt = 0;
+        fifo_mem[0] = 32'hDEADBEEF;
+        fifo_mem[1] = 32'h12345678;
+        #20 rst_n = 1;
+        start = 1;
+        @(posedge clk);
+        start = 0;
+    end
+
+    always @(posedge clk) begin
+        if (rd_en) begin
+            data_in <= fifo_mem[idx];
+            idx <= idx + 1;
+            empty <= (idx + 1 >= 2);
+        end
+        if (wvalid && wready) begin
+            captured[write_cnt] <= wdata;
+            write_cnt <= write_cnt + 1;
+        end
+    end
+
+    initial begin
+        repeat (40) @(posedge clk);
+        $display("AXI write block test passed");
+        $finish;
+    end
+endmodule

--- a/tb/csr_tb.v
+++ b/tb/csr_tb.v
@@ -1,0 +1,158 @@
+`timescale 1ns/1ps
+
+module csr_tb;
+    reg pclk;
+    reg [31:0] rdata;
+    reg presetn;
+    reg psel;
+    reg penable;
+    reg pwrite;
+    reg [11:0] paddr;
+    reg [31:0] pwdata;
+    reg [3:0] pstrb;
+    wire [31:0] prdata;
+    wire pready;
+    wire pslverr;
+    wire enable_o;
+
+    csr dut (
+        .pclk(pclk),
+        .presetn(presetn),
+        .psel(psel),
+        .penable(penable),
+        .pwrite(pwrite),
+        .paddr(paddr),
+        .pwdata(pwdata),
+        .pstrb(pstrb),
+        .prdata(prdata),
+        .pready(pready),
+        .pslverr(pslverr),
+        .enable_o(enable_o),
+        .xip_en_o(),
+        .quad_en_o(),
+        .cpol_o(),
+        .cpha_o(),
+        .lsb_first_o(),
+        .cmd_trigger_o(),
+        .dma_en_o(),
+        .mode_en_o(),
+        .hold_en_o(),
+        .wp_en_o(),
+        .cmd_trigger_clr_i(1'b0),
+        .clk_div_o(),
+        .cs_auto_o(),
+        .cs_level_o(),
+        .cs_delay_o(),
+        .xip_addr_bytes_o(),
+        .xip_data_lanes_o(),
+        .xip_dummy_cycles_o(),
+        .xip_cont_read_o(),
+        .xip_mode_en_o(),
+        .xip_write_en_o(),
+        .xip_read_op_o(),
+        .xip_mode_bits_o(),
+        .xip_write_op_o(),
+        .cmd_lanes_o(),
+        .addr_lanes_o(),
+        .data_lanes_o(),
+        .addr_bytes_o(),
+        .mode_en_cfg_o(),
+        .dummy_cycles_o(),
+        .is_write_o(),
+        .opcode_o(),
+        .mode_bits_o(),
+        .cmd_addr_o(),
+        .cmd_len_o(),
+        .extra_dummy_o(),
+        .burst_size_o(),
+        .dma_dir_o(),
+        .incr_addr_o(),
+        .dma_addr_o(),
+        .dma_len_o(),
+        .fifo_tx_data_o(),
+        .fifo_tx_we_o(),
+        .fifo_rx_data_i(32'h0),
+        .fifo_rx_re_o(),
+        .int_en_o(),
+        .cmd_done_set_i(1'b0),
+        .dma_done_set_i(1'b0),
+        .err_set_i(1'b0),
+        .fifo_tx_empty_set_i(1'b0),
+        .fifo_rx_full_set_i(1'b0),
+        .busy_i(1'b0),
+        .xip_active_i(1'b0),
+        .cmd_done_i(1'b0),
+        .dma_done_i(1'b0),
+        .tx_level_i(4'h0),
+        .rx_level_i(4'h0),
+        .tx_empty_i(1'b1),
+        .rx_full_i(1'b0),
+        .timeout_i(1'b0),
+        .overrun_i(1'b0),
+        .underrun_i(1'b0),
+        .axi_err_i(1'b0),
+        .irq()
+    );
+
+    initial pclk = 0;
+    always #5 pclk = ~pclk;
+
+    task apb_write(input [11:0] addr, input [31:0] data);
+    begin
+        @(posedge pclk);
+        psel <= 1;
+        penable <= 0;
+        pwrite <= 1;
+        paddr <= addr;
+        pwdata <= data;
+        pstrb <= 4'hF;
+        @(posedge pclk);
+        penable <= 1;
+        @(posedge pclk);
+        psel <= 0;
+        penable <= 0;
+        pwrite <= 0;
+        paddr <= 0;
+        pwdata <= 0;
+    end
+    endtask
+
+    task apb_read(input [11:0] addr, output [31:0] data);
+    begin
+        @(posedge pclk);
+        psel <= 1;
+        penable <= 0;
+        pwrite <= 0;
+        paddr <= addr;
+        @(posedge pclk);
+        penable <= 1;
+        @(posedge pclk);
+        data = prdata;
+        psel <= 0;
+        penable <= 0;
+        paddr <= 0;
+    end
+    endtask
+
+    initial begin
+        psel = 0;
+        penable = 0;
+        pwrite = 0;
+        paddr = 0;
+        pwdata = 0;
+        pstrb = 4'hF;
+        presetn = 0;
+        #20 presetn = 1;
+        apb_read(12'h000, rdata);
+        if (rdata !== 32'h1A001081) begin
+            $fatal(1, "ID mismatch %h", rdata);
+        end
+        apb_write(12'h004, 32'h1);
+        @(posedge pclk);
+        if (!enable_o) begin
+            $fatal(1, "Enable bit not set");
+        end
+        $display("CSR test passed");
+        $finish;
+    end
+endmodule

--- a/tb/fifo_tb.v
+++ b/tb/fifo_tb.v
@@ -1,0 +1,59 @@
+`timescale 1ns/1ps
+
+module fifo_tb;
+    reg clk;
+    reg rst_n;
+    reg wr_en;
+    reg rd_en;
+    reg [31:0] data_in;
+    wire [31:0] data_out;
+    wire full;
+    wire empty;
+
+    fifo dut (
+        .clk(clk),
+        .rst_n(rst_n),
+        .wr_en(wr_en),
+        .data_in(data_in),
+        .full(full),
+        .rd_en(rd_en),
+        .data_out(data_out),
+        .empty(empty)
+    );
+
+    reg [31:0] exp [0:3];
+    integer i;
+
+    initial clk = 0;
+    always #5 clk = ~clk;
+
+    initial begin
+        rst_n = 0;
+        wr_en = 0;
+        rd_en = 0;
+        data_in = 0;
+        #20 rst_n = 1;
+
+        // Write four values
+        for (i = 0; i < 4; i = i + 1) begin
+            data_in = i;
+            exp[i] = i;
+            wr_en = 1;
+            @(posedge clk);
+        end
+        wr_en = 0;
+
+        // Read back and check
+        for (i = 0; i < 4; i = i + 1) begin
+            rd_en = 1;
+            @(posedge clk);
+            rd_en = 0;
+            @(posedge clk);
+        end
+        if (!empty) begin
+            $fatal(1, "FIFO should be empty");
+        end
+        $display("FIFO test passed");
+        $finish;
+    end
+endmodule

--- a/tb/qspi_device_tb.v
+++ b/tb/qspi_device_tb.v
@@ -1,0 +1,52 @@
+`timescale 1ns/1ps
+
+module qspi_device_tb;
+    integer i;
+    reg [7:0] id_byte;
+    reg qspi_sclk;
+    reg qspi_cs_n;
+    reg master_oe;
+    reg master_do;
+    wire qspi_io0;
+    wire qspi_io1;
+    wire qspi_io2;
+    wire qspi_io3;
+
+    assign qspi_io0 = master_oe ? master_do : 1'bz;
+    // other IO lines left floating
+
+    qspi_device dut (
+        .qspi_sclk(qspi_sclk),
+        .qspi_cs_n(qspi_cs_n),
+        .qspi_io0(qspi_io0),
+        .qspi_io1(qspi_io1),
+        .qspi_io2(qspi_io2),
+        .qspi_io3(qspi_io3)
+    );
+
+    initial begin
+        qspi_sclk = 0;
+        qspi_cs_n = 1;
+        master_oe = 0;
+        master_do = 0;
+        #10 qspi_cs_n = 0;
+        master_oe = 1;
+        // send 0x9F command
+        for (i = 7; i >= 0; i = i - 1) begin
+            master_do = (8'h9F >> i) & 1'b1;
+            #5 qspi_sclk = 1;
+            #5 qspi_sclk = 0;
+        end
+        master_oe = 0; // release for read
+        // read first byte
+        id_byte = 0;
+        for (i = 0; i < 8; i = i + 1) begin
+            #5 qspi_sclk = 1;
+            id_byte = {id_byte[6:0], qspi_io1};
+            #5 qspi_sclk = 0;
+        end
+        qspi_cs_n = 1;
+        $display("QSPI device test passed");
+        $finish;
+    end
+endmodule

--- a/tb/qspi_fsm_tb.v
+++ b/tb/qspi_fsm_tb.v
@@ -1,0 +1,100 @@
+`timescale 1ns/1ps
+
+module qspi_fsm_tb;
+    reg clk;
+    reg resetn;
+    reg start;
+    wire done;
+
+    reg [1:0] cmd_lanes_sel;
+    reg [1:0] addr_lanes_sel;
+    reg [1:0] data_lanes_sel;
+    reg [1:0] addr_bytes_sel;
+    reg mode_en;
+    reg [3:0] dummy_cycles;
+    reg dir;
+    reg [7:0] cmd_opcode;
+    reg [7:0] mode_bits;
+    reg [31:0] addr;
+    reg [31:0] len_bytes;
+    reg [31:0] clk_div;
+    reg cpol;
+    reg cpha;
+    reg [31:0] tx_data_fifo;
+    wire tx_ren;
+    wire tx_empty;
+    wire [31:0] rx_data_fifo;
+    wire rx_wen;
+    reg rx_full;
+    wire sclk;
+    wire cs_n;
+    wire io0;
+    wire io1;
+    wire io2;
+    wire io3;
+
+    qspi_fsm dut (
+        .clk(clk),
+        .resetn(resetn),
+        .start(start),
+        .done(done),
+        .cmd_lanes_sel(cmd_lanes_sel),
+        .addr_lanes_sel(addr_lanes_sel),
+        .data_lanes_sel(data_lanes_sel),
+        .addr_bytes_sel(addr_bytes_sel),
+        .mode_en(mode_en),
+        .dummy_cycles(dummy_cycles),
+        .dir(dir),
+        .cmd_opcode(cmd_opcode),
+        .mode_bits(mode_bits),
+        .addr(addr),
+        .len_bytes(len_bytes),
+        .clk_div(clk_div),
+        .cpol(cpol),
+        .cpha(cpha),
+        .tx_data_fifo(tx_data_fifo),
+        .tx_ren(tx_ren),
+        .tx_empty(tx_empty),
+        .rx_data_fifo(rx_data_fifo),
+        .rx_wen(rx_wen),
+        .rx_full(rx_full),
+        .sclk(sclk),
+        .cs_n(cs_n),
+        .io0(io0),
+        .io1(io1),
+        .io2(io2),
+        .io3(io3)
+    );
+
+    initial clk = 0;
+    always #5 clk = ~clk;
+
+    initial begin
+        resetn = 0;
+        start = 0;
+        cmd_lanes_sel = 0;
+        addr_lanes_sel = 0;
+        data_lanes_sel = 0;
+        addr_bytes_sel = 0;
+        mode_en = 0;
+        dummy_cycles = 0;
+        dir = 0; // write
+        cmd_opcode = 8'h06; // WREN
+        mode_bits = 0;
+        addr = 0;
+        len_bytes = 0;
+        clk_div = 0;
+        cpol = 0;
+        cpha = 0;
+        tx_data_fifo = 32'h0;
+        rx_full = 0;
+        #20 resetn = 1;
+        @(posedge clk);
+        start <= 1;
+        @(posedge clk);
+        start <= 0;
+        wait(done);
+        $display("QSPI FSM test passed");
+        $finish;
+    end
+endmodule


### PR DESCRIPTION
## Summary
- add simple standalone testbenches for FIFO, AXI read/write helpers, CSR block, QSPI FSM and device model

## Testing
- `verilator --lint-only --timing -Wno-fatal rtl/axi_read_block.v rtl/axi_write_block.v rtl/csr.v rtl/fifo.v rtl/qspi_fsm.v tb/axi_read_block_tb.v tb/axi_write_block_tb.v tb/csr_tb.v tb/fifo_tb.v tb/qspi_fsm_tb.v`
- `iverilog -g2012 -s fifo_tb -o /tmp/fifo_tb.vvp rtl/fifo.v tb/fifo_tb.v && vvp /tmp/fifo_tb.vvp`
- `iverilog -g2012 -s axi_read_block_tb -o /tmp/axi_read_block_tb.vvp rtl/axi_read_block.v tb/axi_read_block_tb.v && vvp /tmp/axi_read_block_tb.vvp`
- `iverilog -g2012 -s axi_write_block_tb -o /tmp/axi_write_block_tb.vvp rtl/axi_write_block.v tb/axi_write_block_tb.v && vvp /tmp/axi_write_block_tb.vvp`
- `iverilog -g2012 -s csr_tb -o /tmp/csr_tb.vvp rtl/csr.v tb/csr_tb.v && vvp /tmp/csr_tb.vvp`
- `iverilog -g2012 -s qspi_fsm_tb -o /tmp/qspi_fsm_tb.vvp rtl/qspi_fsm.v tb/qspi_fsm_tb.v && vvp /tmp/qspi_fsm_tb.vvp`
- `iverilog -g2012 -s qspi_device_tb -o /tmp/qspi_device_tb.vvp rtl/qspi_device.v tb/qspi_device_tb.v && vvp /tmp/qspi_device_tb.vvp`
