### PR TITLE
Improve testbench checks

### DIFF
--- a/tb/fifo_tb.v
+++ b/tb/fifo_tb.v
@@ -42,6 +42,9 @@ module fifo_tb;
             @(posedge clk);
         end
         wr_en = 0;
+        // Full/empty sanity after writes
+        if (full) $fatal(1, "FIFO should not be full after 4 writes");
+        if (empty) $fatal(1, "FIFO should not be empty after writes");
 
         // Read back and check
         for (i = 0; i < 4; i = i + 1) begin
@@ -49,10 +52,11 @@ module fifo_tb;
             @(posedge clk);
             rd_en = 0;
             @(posedge clk);
+            if (data_out !== exp[i]) begin
+                $fatal(1, "FIFO data mismatch at %0d: got %h exp %h", i, data_out, exp[i]);
+            end
         end
-        if (!empty) begin
-            $fatal(1, "FIFO should be empty");
-        end
+        if (!empty) $fatal(1, "FIFO should be empty at end");
         $display("FIFO test passed");
         $finish;
     end

--- a/tb/qspi_fsm_tb.v
+++ b/tb/qspi_fsm_tb.v
@@ -22,7 +22,7 @@ module qspi_fsm_tb;
     reg cpha;
     reg [31:0] tx_data_fifo;
     wire tx_ren;
-    wire tx_empty;
+    reg tx_empty;   // was wire
     wire [31:0] rx_data_fifo;
     wire rx_wen;
     reg rx_full;
@@ -87,6 +87,7 @@ module qspi_fsm_tb;
         cpol = 0;
         cpha = 0;
         tx_data_fifo = 32'h0;
+        tx_empty = 1'b1;  // no TX words needed for WREN
         rx_full = 0;
         #20 resetn = 1;
         @(posedge clk);


### PR DESCRIPTION
## Summary
- add AXI write data and done verification
- strengthen FIFO test to validate data and flags
- drive `tx_empty` in QSPI FSM testbench

## Testing
- `verilator --lint-only -Wall --timing --Wno-fatal tb/axi_write_block_tb.v rtl/axi_write_block.v`
- `verilator --lint-only -Wall --timing --Wno-fatal tb/fifo_tb.v rtl/fifo.v`
- `verilator --lint-only -Wall --timing --Wno-fatal tb/qspi_fsm_tb.v rtl/qspi_fsm.v`
- `vvp tb/axi_write_block_tb.vvp` *(failed: simulation hung, manual stop)*
- `vvp tb/fifo_tb.vvp` *(failed: FIFO data mismatch)*
- `iverilog -g2012 -s qspi_fsm_tb -o tb/qspi_fsm_tb.vvp tb/qspi_fsm_tb.v rtl/qspi_fsm.v` *(failed: tx_empty direction mismatch)*
