### PR TITLE
Refactor RTL to use synchronous reset and add parameterized FIFO

### DIFF
--- a/rtl/axi_read_block.v
+++ b/rtl/axi_read_block.v
@@ -1,6 +1,6 @@
 module axi_read_block (
     input wire          clk,
-    input wire          rst_n,
+    input wire          reset,
 
     input wire          start,
     input wire  [31:0]  addr,
@@ -31,8 +31,8 @@ module axi_read_block (
     reg [15:0] count;
     reg [31:0] addr_reg;
 
-    always @(posedge clk or negedge rst_n) begin
-        if (!rst_n) begin
+    always @(posedge clk) begin
+        if (reset) begin
             state     <= IDLE;
             count     <= 0;
             addr_reg  <= 0;

--- a/rtl/axi_write_block.v
+++ b/rtl/axi_write_block.v
@@ -1,6 +1,6 @@
 module axi_write_block (
     input wire          clk,
-    input wire          rst_n,
+    input wire          reset,
 
     input wire          start,
     input wire  [31:0]  addr,
@@ -39,8 +39,8 @@ module axi_write_block (
     reg [15:0] count;
     reg [31:0] addr_reg;
 
-    always @(posedge clk or negedge rst_n) begin
-        if (!rst_n) begin
+    always @(posedge clk) begin
+        if (reset) begin
             state     <= IDLE;
             count     <= 0;
             addr_reg  <= 0;

--- a/rtl/fifo.v
+++ b/rtl/fifo.v
@@ -1,43 +1,56 @@
-module fifo (
-    input wire clk,
-    input wire rst_n,
-    input wire wr_en,        // Write enable signal
-    input wire [31:0] data_in,  // Data to be written
-    output reg full,         // Full flag
-    input wire rd_en,        // Read enable signal
-    output reg [31:0] data_out, // Data read from FIFO
-    output reg empty         // Empty flag
+module fifo #(
+    parameter ADDR_WIDTH = 8,
+    parameter DEPTH = 1 << ADDR_WIDTH
+) (
+    input  wire        clk,
+    input  wire        reset,
+    input  wire        wr_en,
+    input  wire [31:0] data_in,
+    output reg         full,
+    input  wire        rd_en,
+    output reg  [31:0] data_out,
+    output reg         empty
 );
 
-    // FIFO storage
-    reg [31:0] mem [0:255];  // FIFO size: 256 entries (32-bit words)
-    reg [7:0] write_ptr;     // Write pointer
-    reg [7:0] read_ptr;      // Read pointer
+    reg [31:0] mem [0:DEPTH-1];
+    reg [ADDR_WIDTH-1:0] wptr;
+    reg [ADDR_WIDTH-1:0] rptr;
+    reg [ADDR_WIDTH:0]   count;
+    reg [ADDR_WIDTH:0]   next_count;
 
-    // FIFO write operation
-    always @(posedge clk or negedge rst_n) begin
-        if (!rst_n) begin
-            write_ptr <= 8'd0;
-            read_ptr  <= 8'd0;
+    always @(posedge clk) begin
+        if (reset) begin
+            wptr      <= {ADDR_WIDTH{1'b0}};
+            rptr      <= {ADDR_WIDTH{1'b0}};
+            count     <= {(ADDR_WIDTH+1){1'b0}};
             full      <= 1'b0;
             empty     <= 1'b1;
             data_out  <= 32'd0;
         end else begin
-            // Write operation
-            if (wr_en && !full) begin
-                mem[write_ptr] <= data_in;
-                write_ptr <= write_ptr + 1;
-            end
-
-            // Read operation
-            if (rd_en && !empty) begin
-                data_out <= mem[read_ptr];
-                read_ptr  <= read_ptr + 1;
-            end
-
-            // Update full and empty flags
-            full  <= (write_ptr == (read_ptr - 1)) ? 1'b1 : 1'b0;
-            empty <= (write_ptr == read_ptr) ? 1'b1 : 1'b0;
+            next_count = count;
+            case ({wr_en & ~full, rd_en & ~empty})
+                2'b10: begin
+                    mem[wptr] <= data_in;
+                    wptr      <= wptr + 1'b1;
+                    next_count = count + 1'b1;
+                end
+                2'b01: begin
+                    data_out  <= mem[rptr];
+                    rptr      <= rptr + 1'b1;
+                    next_count = count - 1'b1;
+                end
+                2'b11: begin
+                    mem[wptr] <= data_in;
+                    wptr      <= wptr + 1'b1;
+                    data_out  <= mem[rptr];
+                    rptr      <= rptr + 1'b1;
+                end
+                default: begin
+                end
+            endcase
+            count <= next_count;
+            full  <= (next_count == DEPTH);
+            empty <= (next_count == 0);
         end
     end
 endmodule


### PR DESCRIPTION
## Summary
- replace simplistic FIFO with configurable synchronous implementation based on reference design
- convert QSPI FSM and AXI helper blocks to active-high synchronous reset and fix tx_empty handling
- update CSR logic to use synchronous reset and clean width handling

## Testing
- `verilator --lint-only -Wno-fatal rtl/axi_read_block.v rtl/axi_write_block.v rtl/csr.v rtl/fifo.v rtl/qspi_fsm.v`
- `iverilog -g2012 -s qspi_fsm -o /tmp/qspi_fsm.vvp rtl/axi_read_block.v rtl/axi_write_block.v rtl/csr.v rtl/fifo.v rtl/qspi_fsm.v`
