### PR TITLE
Rewrite QSPI FSM for MSB-first shifting and CS control

### DIFF
--- a/rtl/qspi_fsm.v
+++ b/rtl/qspi_fsm.v
@@ -1,363 +1,450 @@
+// qspi_fsm.v - QSPI flash transaction finite state machine
+// Generates command, address, dummy and data phases for SPI/Dual/Quad
+// operations. Shifts data MSB-first on IO[3:0] and interfaces with FIFO
+// blocks for streaming write and read data. Chip select timing honours
+// cs_auto and continuous read hold from CSR.
+
 module qspi_fsm #(
     parameter ADDR_WIDTH = 32
 )(
-    input wire clk,
-    input wire reset,
+    input  wire        clk,
+    input  wire        resetn,
 
-    // Kick start & done
-    input wire start,   // pulse to start a transaction
-    output wire done,
+    // start & completion
+    input  wire        start,
+    output wire        done,
 
-    // CMD_CFG
-    input wire [1:0] cmd_lanes_sel,  // 0:1bit,1:2bit,2:4bit (CMD LANES)
-    input wire [1:0] addr_lanes_sel, // 0:1bit,1:2bit,2:4bit (ADDR LANES)
-    input wire [1:0] data_lanes_sel, // 0:1bit,1:2bit,2:4bit (DATA LANES)
-    input wire [1:0] addr_bytes_sel, // 0:0B, 1:3B, 2:4B
-    input wire mode_en,              // MODE EN
-    input wire [3:0] dummy_cycles,   // Number of dummy clock cycles
-    input wire dir,                  // 0:Write(Tx) -1:Read(Rx) (DIR)
+    // configuration
+    input  wire [1:0]  cmd_lanes_sel,
+    input  wire [1:0]  addr_lanes_sel,
+    input  wire [1:0]  data_lanes_sel,
+    input  wire [1:0]  addr_bytes_sel,   // 0:0B 1:3B 2:4B
+    input  wire        mode_en,
+    input  wire [3:0]  dummy_cycles,
+    input  wire        dir,              // 0:write 1:read
+    input  wire        quad_en,
+    input  wire        cs_auto,
+    input  wire        xip_cont_read,
 
-    // CMD_OP
-    input wire [7:0] cmd_opcode,
-    input wire [7:0] mode_bits,
+    // opcode/mode/address
+    input  wire [7:0]  cmd_opcode,
+    input  wire [7:0]  mode_bits,
+    input  wire [ADDR_WIDTH-1:0] addr,
+    input  wire [31:0] len_bytes,
 
-    // CMD_ADDR
-    input wire [ADDR_WIDTH-1:0] addr,
+    // clock control
+    input  wire [31:0] clk_div,
+    input  wire        cpol,
+    input  wire        cpha,
 
-    // CMD_LEN
-    input wire [31:0] len_bytes,
+    // write path
+    input  wire [31:0] tx_data_fifo,
+    input  wire        tx_empty,
+    output wire        tx_ren,
 
-    // CTRL bits for SPI clocking
-    input wire [31:0] clk_div,
+    // read path
+    output reg  [31:0] rx_data_fifo,
+    output reg         rx_wen,
+    input  wire        rx_full,
 
-    // CPOL and CPHA
-    input wire cpol,
-    input wire cpha,
-
-    // Write path (DIR=0)
-    input wire [31:0] tx_data_fifo,
-    output wire tx_ren,
-    input  wire tx_empty,
-
-    // Read path (DIR=1)
-    output reg [31:0] rx_data_fifo,
-    output reg rx_wen,
-    input wire rx_full,
-
-    // QSPI Pins
-    output wire sclk,
-    output reg cs_n,
-    inout wire io0,
-    inout wire io1,
-    inout wire io2,
-    inout wire io3
+    // QSPI pins
+    output wire        sclk,
+    output reg         cs_n,
+    inout  wire        io0,
+    inout  wire        io1,
+    inout  wire        io2,
+    inout  wire        io3
 );
 
-// CMD OPCODE
-// Read
-localparam READ       = 8'h03; // Read Data Bytes
-localparam FAST_READ  = 8'h0B; // Read Data Bytes at Higher Speed
-localparam READ_2     = 8'hBB; // 2 x I/O Read Mode
-localparam QREAD      = 8'h6B; // Quad I/O Read Mode
-localparam READ_4     = 8'hEB; // 4 x I/O Read Mode
-
-// Write
-localparam SE         = 8'h20; // Sector Erase
-localparam BE         = 8'hD8; // Block Erase
-localparam CE         = 8'h60; // Chip Erase
-localparam PP         = 8'h02; // Page Program
-localparam PP_4       = 8'h38; // 4 x I/O Page Program
-localparam WREN       = 8'h06; // Write Enable
-
-// State Machine
-localparam IDLE       = 4'd0,
-           CS         = 4'd1,
-           CMD        = 4'd2,
-           ADDR       = 4'd3,
-           MODE       = 4'd4,
-           DUMMY      = 4'd5,
-           DATA       = 4'd6,
-           STOP_CS    = 4'd7;
-
-    reg [3:0] state, next_state;
-    reg [31:0] bit_cnt, next_bit_cnt;
-    reg [31:0] byte_cnt, next_byte_cnt;
-    reg [2:0]  lanes, next_lanes;
-    reg [31:0] data_shift_reg, next_data_shift_reg;
-    reg [3:0]  io_oe, next_io_oe;
-    reg [3:0]  dummy_left, next_dummy_left;
-
-    reg [2:0] cmd_lanes_eff, addr_lanes_eff, data_lanes_eff;
-    reg [5:0] addr_bits;
-
-    // SCLK engine
-    reg        sclk_en, next_sclk_en;
-    reg [31:0] sclk_cnt;
-    reg        sclk_q;
-    reg        sclk_edge;
-    reg        sclk_phase;
-
-    // QSPI I/O
-    wire [3:0] io_di = {io3, io2, io1, io0};
-    reg  [3:0] out_bits;
-    reg  [3:0] input_bits;
-
-    // CPHA/CPOL edge decode
-    wire shift_pulse  = sclk_edge & (cpha ? (sclk_phase==1'b0) : (sclk_phase==1'b1));
-    wire sample_pulse = sclk_edge & ~shift_pulse;
-    wire bit_tick     = sample_pulse;
-
-    // Done
-    assign done = (state == STOP_CS);
-
-    // Tri-state mapping
-    assign io3 = io_oe[3] ? out_bits[3] : 1'bz;
-    assign io2 = io_oe[2] ? out_bits[2] : 1'bz;
-    assign io1 = io_oe[1] ? out_bits[1] : 1'bz;
-    assign io0 = io_oe[0] ? out_bits[0] : 1'bz;
-
-    // Output bit mux
-    always @* begin
-        case (lanes)
-            3'd1: out_bits = {3'b000, data_shift_reg[31]};
-            3'd2: out_bits = {2'b00, data_shift_reg[31], data_shift_reg[30]};
-            3'd4: out_bits = {data_shift_reg[31], data_shift_reg[30], data_shift_reg[29], data_shift_reg[28]};
-            default: out_bits = 4'b0000;
-        endcase
-        case (lanes)
-            3'd1: input_bits = {3'b000, io_di[1]};
-            3'd2: input_bits = {2'b00, io_di[1:0]};
-            3'd4: input_bits = io_di[3:0];
-            default: input_bits = 4'b0000;
+// ------------------------------------------------------------
+// Lane decode helpers
+// ------------------------------------------------------------
+function [2:0] lane_decode;
+    input [1:0] sel;
+    begin
+        case (sel)
+            2'b00: lane_decode = 3'd1;
+            2'b01: lane_decode = 3'd2;
+            default: lane_decode = quad_en ? 3'd4 : 3'd1;
         endcase
     end
+endfunction
 
-    // SCLK output
-    assign sclk = sclk_en ? sclk_q : cpol;
+function [3:0] lane_mask;
+    input [2:0] lanes;
+    begin
+        case (lanes)
+            3'd1: lane_mask = 4'b0001;
+            3'd2: lane_mask = 4'b0011;
+            3'd4: lane_mask = 4'b1111;
+            default: lane_mask = 4'b0000;
+        endcase
+    end
+endfunction
 
-    // SCLK generator
-    always @(posedge clk) begin
-        if (reset) begin
-            sclk_cnt   <= 0;
+// Opcode specific lane overrides
+reg [2:0] cmd_lanes_eff, addr_lanes_eff, data_lanes_eff;
+always @* begin
+    case (cmd_opcode)
+        8'h3B: begin // Dual Output Read 1-1-2
+            cmd_lanes_eff  = 3'd1;
+            addr_lanes_eff = 3'd1;
+            data_lanes_eff = 3'd2;
+        end
+        8'hBB: begin // Dual I/O Read 1-2-2
+            cmd_lanes_eff  = 3'd1;
+            addr_lanes_eff = 3'd2;
+            data_lanes_eff = 3'd2;
+        end
+        8'h6B: begin // Quad Output Read 1-1-4
+            cmd_lanes_eff  = 3'd1;
+            addr_lanes_eff = 3'd1;
+            data_lanes_eff = quad_en ? 3'd4 : 3'd1;
+        end
+        8'hEB: begin // Quad I/O Read 1-4-4
+            cmd_lanes_eff  = 3'd1;
+            addr_lanes_eff = quad_en ? 3'd4 : 3'd1;
+            data_lanes_eff = quad_en ? 3'd4 : 3'd1;
+        end
+        default: begin
+            cmd_lanes_eff  = lane_decode(cmd_lanes_sel);
+            addr_lanes_eff = lane_decode(addr_lanes_sel);
+            data_lanes_eff = lane_decode(data_lanes_sel);
+        end
+    endcase
+end
+
+wire [5:0] addr_bits = (addr_bytes_sel==2'b01) ? 6'd24 :
+                       (addr_bytes_sel==2'b10) ? 6'd32 : 6'd0;
+
+// ------------------------------------------------------------
+// SCLK generator
+// ------------------------------------------------------------
+reg        sclk_en, sclk_en_n;
+reg [31:0] sclk_cnt;
+reg        sclk_q;
+reg        sclk_edge;
+reg        sclk_phase;
+
+assign sclk = sclk_en ? sclk_q : cpol;
+
+always @(posedge clk or negedge resetn) begin
+    if (!resetn) begin
+        sclk_cnt   <= 32'd0;
+        sclk_q     <= 1'b0;
+        sclk_edge  <= 1'b0;
+        sclk_phase <= 1'b0;
+    end else begin
+        sclk_edge <= 1'b0;
+        if (!sclk_en) begin
+            sclk_cnt   <= 32'd0;
             sclk_q     <= cpol;
-            sclk_edge  <= 1'b0;
             sclk_phase <= 1'b0;
         end else begin
-            sclk_edge <= 1'b0;
-            if (!sclk_en) begin
-                sclk_cnt   <= 0;
-                sclk_q     <= cpol;
-                sclk_phase <= 1'b0;
+            if (sclk_cnt >= clk_div) begin
+                sclk_cnt   <= 32'd0;
+                sclk_q     <= ~sclk_q;
+                sclk_edge  <= 1'b1;
+                sclk_phase <= ~sclk_phase;
             end else begin
-                if (sclk_cnt >= clk_div) begin
-                    sclk_cnt   <= 0;
-                    sclk_q     <= ~sclk_q;
-                    sclk_edge  <= 1'b1;
-                    sclk_phase <= ~sclk_phase;
-                end else begin
-                    sclk_cnt <= sclk_cnt + 1;
-                end
+                sclk_cnt <= sclk_cnt + 1;
             end
         end
     end
+end
 
-    // Sequential state registers
-    always @(posedge clk) begin
-        if (reset) begin
-            state <= IDLE;
-            cs_n  <= 1'b1;
-            bit_cnt <= 0;
-            byte_cnt <= 0;
-            lanes <= 3'd1;
-            data_shift_reg <= 0;
-            io_oe <= 0;
-            sclk_en <= 0;
-            dummy_left <= 0;
-        end else begin
-            state <= next_state;
-            cs_n  <= (next_state==IDLE || next_state==STOP_CS);
-            bit_cnt <= next_bit_cnt;
-            byte_cnt <= next_byte_cnt;
-            lanes <= next_lanes;
-            data_shift_reg <= next_data_shift_reg;
-            io_oe <= next_io_oe;
-            sclk_en <= next_sclk_en;
-            dummy_left <= next_dummy_left;
+wire shift_pulse  = sclk_edge & (cpha ? ~sclk_phase : sclk_phase);
+wire sample_pulse = sclk_edge & ~shift_pulse;
+wire bit_tick     = sample_pulse;
+
+// ------------------------------------------------------------
+// IO handling
+// ------------------------------------------------------------
+reg [2:0] lanes, lanes_n;
+reg [31:0] shreg, shreg_n;
+reg [5:0]  bit_cnt, bit_cnt_n;
+reg [31:0] byte_cnt, byte_cnt_n;
+reg [3:0]  dummy_cnt, dummy_cnt_n;
+reg [3:0]  io_oe, io_oe_n;
+
+wire [3:0] io_di = {io3, io2, io1, io0};
+reg  [3:0] out_bits, in_bits;
+
+always @* begin
+    case (lanes)
+        3'd1: begin
+            out_bits = {3'b000, shreg[31]};
+            in_bits  = {3'b000, io_di[1]};
         end
+        3'd2: begin
+            out_bits = {2'b00, shreg[31], shreg[30]};
+            in_bits  = {2'b00, io_di[1:0]};
+        end
+        3'd4: begin
+            out_bits = shreg[31:28];
+            in_bits  = io_di[3:0];
+        end
+        default: begin
+            out_bits = 4'b0000;
+            in_bits  = 4'b0000;
+        end
+    endcase
+end
+
+assign io0 = io_oe[0] ? out_bits[0] : 1'bz;
+assign io1 = io_oe[1] ? out_bits[1] : 1'bz;
+assign io2 = io_oe[2] ? out_bits[2] : 1'bz;
+assign io3 = io_oe[3] ? out_bits[3] : 1'bz;
+
+// ------------------------------------------------------------
+// State machine
+// ------------------------------------------------------------
+localparam [3:0]
+    IDLE      = 4'd0,
+    CS_SETUP  = 4'd1,
+    CMD_BIT   = 4'd2,
+    ADDR_BIT  = 4'd3,
+    MODE_BIT  = 4'd4,
+    DUMMY_BIT = 4'd5,
+    DATA_BIT  = 4'd6,
+    CS_HOLD   = 4'd7,
+    CS_DONE   = 4'd8;
+
+reg [3:0] state, state_n;
+reg       cs_n_n;
+
+assign done = (state == CS_DONE) || (state == CS_HOLD);
+
+always @(posedge clk or negedge resetn) begin
+    if (!resetn) begin
+        state     <= IDLE;
+        cs_n      <= 1'b1;
+        lanes     <= 3'd1;
+        shreg     <= 32'b0;
+        bit_cnt   <= 6'd0;
+        byte_cnt  <= 32'd0;
+        dummy_cnt <= 4'd0;
+        io_oe     <= 4'b0;
+        sclk_en   <= 1'b0;
+    end else begin
+        state     <= state_n;
+        cs_n      <= cs_n_n;
+        lanes     <= lanes_n;
+        shreg     <= shreg_n;
+        bit_cnt   <= bit_cnt_n;
+        byte_cnt  <= byte_cnt_n;
+        dummy_cnt <= dummy_cnt_n;
+        io_oe     <= io_oe_n;
+        sclk_en   <= sclk_en_n;
     end
+end
 
-    // FSM
-    always @* begin
-        // defaults
-        next_state = state;
-        next_bit_cnt = bit_cnt;
-        next_byte_cnt = byte_cnt;
-        next_lanes = lanes;
-        next_data_shift_reg = data_shift_reg;
-        next_io_oe = io_oe;
-        next_sclk_en = 1'b0;
-        next_dummy_left = dummy_left;
-        rx_wen = 1'b0;
-        rx_data_fifo = 32'b0;
+always @* begin
+    // Defaults
+    state_n     = state;
+    lanes_n     = lanes;
+    shreg_n     = shreg;
+    bit_cnt_n   = bit_cnt;
+    byte_cnt_n  = byte_cnt;
+    dummy_cnt_n = dummy_cnt;
+    io_oe_n     = 4'b0000;
+    sclk_en_n   = 1'b0;
+    rx_wen       = 1'b0;
+    rx_data_fifo = 32'b0;
+    cs_n_n       = cs_n;
 
-        // lane decode
-        cmd_lanes_eff  = (cmd_lanes_sel==2'b00)?3'd1:(cmd_lanes_sel==2'b01)?3'd2:3'd4;
-        addr_lanes_eff = (addr_lanes_sel==2'b00)?3'd1:(addr_lanes_sel==2'b01)?3'd2:3'd4;
-        data_lanes_eff = (data_lanes_sel==2'b00)?3'd1:(data_lanes_sel==2'b01)?3'd2:3'd4;
-
-        case (state)
-            IDLE: begin
-                if (start) next_state = CS;
+    case (state)
+        IDLE: begin
+            cs_n_n = 1'b1;
+            if (start) begin
+                state_n   = CS_SETUP;
+                lanes_n   = cmd_lanes_eff;
+                shreg_n   = {cmd_opcode, 24'b0};
+                bit_cnt_n = 6'd0;
             end
+        end
 
-            CS: begin
-                next_state = CMD;
-                next_bit_cnt = 0;
-                next_lanes = cmd_lanes_eff;
-                next_data_shift_reg = {24'b0, cmd_opcode};
-                next_io_oe = (next_lanes==3'd1)?4'b0001:(next_lanes==3'd2)?4'b0011:4'b1111;
+        CS_SETUP: begin
+            io_oe_n = 4'b0000;
+            cs_n_n  = 1'b0;
+            state_n = CMD_BIT;
+        end
+
+        CMD_BIT: begin
+            sclk_en_n = 1'b1;
+            io_oe_n   = lane_mask(lanes);
+            if (shift_pulse)
+                shreg_n = shreg << lanes;
+            if (bit_tick) begin
+                bit_cnt_n = bit_cnt + {3'b000, lanes};
+                if (bit_cnt_n >= 6'd8) begin
+                    bit_cnt_n = 6'd0;
+                    if (addr_bits != 0) begin
+                        state_n = ADDR_BIT;
+                        lanes_n = addr_lanes_eff;
+                        shreg_n = (addr_bytes_sel==2'b01) ? {addr[23:0],8'b0} :
+                                  (addr_bytes_sel==2'b10) ? addr : 32'b0;
+                    end else if (mode_en) begin
+                        state_n = MODE_BIT;
+                        lanes_n = data_lanes_eff;
+                        shreg_n = {mode_bits,24'b0};
+                    end else if (dummy_cycles != 0) begin
+                        state_n   = DUMMY_BIT;
+                        lanes_n   = data_lanes_eff;
+                        dummy_cnt_n = dummy_cycles;
+                    end else if (len_bytes != 0) begin
+                        state_n   = DATA_BIT;
+                        lanes_n   = data_lanes_eff;
+                        shreg_n   = dir ? 32'b0 : tx_data_fifo;
+                        io_oe_n   = dir ? 4'b0000 : lane_mask(data_lanes_eff);
+                        byte_cnt_n = 32'd0;
+                    end else begin
+                        state_n = CS_DONE;
+                    end
+                end
             end
+        end
 
-            CMD: begin
-                next_sclk_en = 1;
-                if (shift_pulse) next_data_shift_reg = data_shift_reg << lanes;
+        ADDR_BIT: begin
+            sclk_en_n = 1'b1;
+            io_oe_n   = lane_mask(lanes);
+            if (shift_pulse)
+                shreg_n = shreg << lanes;
+            if (bit_tick) begin
+                bit_cnt_n = bit_cnt + {3'b000, lanes};
+                if (bit_cnt_n >= addr_bits) begin
+                    bit_cnt_n = 6'd0;
+                    if (mode_en) begin
+                        state_n = MODE_BIT;
+                        lanes_n = data_lanes_eff;
+                        shreg_n = {mode_bits,24'b0};
+                    end else if (dummy_cycles != 0) begin
+                        state_n     = DUMMY_BIT;
+                        lanes_n     = data_lanes_eff;
+                        dummy_cnt_n = dummy_cycles;
+                    end else if (len_bytes != 0) begin
+                        state_n     = DATA_BIT;
+                        lanes_n     = data_lanes_eff;
+                        shreg_n     = dir ? 32'b0 : tx_data_fifo;
+                        io_oe_n     = dir ? 4'b0000 : lane_mask(data_lanes_eff);
+                        byte_cnt_n  = 32'd0;
+                    end else begin
+                        state_n = CS_DONE;
+                    end
+                end
+            end
+        end
+
+        MODE_BIT: begin
+            sclk_en_n = 1'b1;
+            io_oe_n   = lane_mask(lanes);
+            if (shift_pulse)
+                shreg_n = shreg << lanes;
+            if (bit_tick) begin
+                bit_cnt_n = bit_cnt + {3'b000, lanes};
+                if (bit_cnt_n >= 6'd8) begin
+                    bit_cnt_n = 6'd0;
+                    if (dummy_cycles != 0) begin
+                        state_n   = DUMMY_BIT;
+                        lanes_n   = data_lanes_eff;
+                        dummy_cnt_n = dummy_cycles;
+                    end else if (len_bytes != 0) begin
+                        state_n   = DATA_BIT;
+                        lanes_n   = data_lanes_eff;
+                        shreg_n   = dir ? 32'b0 : tx_data_fifo;
+                        io_oe_n   = dir ? 4'b0000 : lane_mask(data_lanes_eff);
+                        byte_cnt_n = 32'd0;
+                    end else begin
+                        state_n = CS_DONE;
+                    end
+                end
+            end
+        end
+
+        DUMMY_BIT: begin
+            sclk_en_n = 1'b1;
+            io_oe_n   = 4'b0000;
+            if (bit_tick) begin
+                if (dummy_cnt != 0)
+                    dummy_cnt_n = dummy_cnt - 1;
+                if (dummy_cnt == 1) begin
+                    if (len_bytes != 0) begin
+                        state_n   = DATA_BIT;
+                        lanes_n   = data_lanes_eff;
+                        shreg_n   = dir ? 32'b0 : tx_data_fifo;
+                        io_oe_n   = dir ? 4'b0000 : lane_mask(data_lanes_eff);
+                        byte_cnt_n = 32'd0;
+                    end else begin
+                        state_n = CS_DONE;
+                    end
+                end
+            end
+        end
+
+        DATA_BIT: begin
+            sclk_en_n = 1'b1;
+            io_oe_n   = dir ? 4'b0000 : lane_mask(lanes);
+            if (dir) begin
+                if (sample_pulse)
+                    shreg_n = (shreg << lanes) | {28'b0, in_bits};
                 if (bit_tick) begin
-                    next_bit_cnt = bit_cnt + {{29{1'b0}}, lanes};
-                    if (next_bit_cnt >= 8) begin
-                        next_bit_cnt = 0;
-                        case (cmd_opcode)
-                            READ, FAST_READ, READ_2, QREAD, READ_4, PP, PP_4: next_state = ADDR;
-                            SE, BE: next_state = ADDR;
-                            CE, WREN: next_state = STOP_CS;
-                            default: next_state = STOP_CS;
-                        endcase
-                        if (next_state==ADDR) begin
-                            next_lanes = addr_lanes_eff;
-                            next_data_shift_reg = (addr_bytes_sel==2'b01)?{8'b0,addr[23:0]}:addr;
-                            next_io_oe = (next_lanes==3'd1)?4'b0001:(next_lanes==3'd2)?4'b0011:4'b1111;
+                    bit_cnt_n = bit_cnt + {3'b000, lanes};
+                    if (bit_cnt_n >= 6'd32) begin
+                        bit_cnt_n = 6'd0;
+                        byte_cnt_n = byte_cnt + 4;
+                        if (!rx_full) begin
+                            rx_wen = 1'b1;
+                            rx_data_fifo = shreg;
                         end
+                        shreg_n = 32'b0;
+                    end
+                    if (byte_cnt_n >= len_bytes) begin
+                        if (xip_cont_read && !cs_auto)
+                            state_n = CS_HOLD;
+                        else
+                            state_n = CS_DONE;
                     end
                 end
-            end
-
-            ADDR: begin
-                next_sclk_en = 1;
-                if (shift_pulse) next_data_shift_reg = data_shift_reg << lanes;
-                  addr_bits = (addr_bytes_sel==2'b01)?6'd24:6'd32;
+            end else begin
+                if (shift_pulse)
+                    shreg_n = shreg << lanes;
                 if (bit_tick) begin
-                    next_bit_cnt = bit_cnt + {{29{1'b0}}, lanes};
-                    if (next_bit_cnt >= addr_bits) begin
-                        next_bit_cnt = 0;
-                        case (cmd_opcode)
-                            READ, FAST_READ, READ_2, QREAD, READ_4: begin
-                                if (mode_en && (cmd_opcode==READ_2 || cmd_opcode==READ_4)) begin
-                                    next_state = MODE;
-                                    next_lanes = data_lanes_eff;
-                                    next_data_shift_reg = {24'b0, mode_bits};
-                                end else if (dummy_cycles!=0 || cmd_opcode!=READ) begin
-                                    next_state = DUMMY;
-                                    next_dummy_left = dummy_cycles;
-                                end else begin
-                                    next_state = DATA;
-                                    next_lanes = data_lanes_eff;
-                                    next_io_oe = dir?4'b0000:((next_lanes==3'd1)?4'b0001:(next_lanes==3'd2)?4'b0011:4'b1111);
-                                    next_data_shift_reg = dir?32'b0:tx_data_fifo;
-                                    next_byte_cnt = 0;
-                                end
-                            end
-                            PP, PP_4: begin
-                                next_state = DATA;
-                                next_lanes = data_lanes_eff;
-                                next_io_oe = (next_lanes==3'd1)?4'b0001:(next_lanes==3'd2)?4'b0011:4'b1111;
-                                next_data_shift_reg = tx_data_fifo;
-                                next_byte_cnt = 0;
-                            end
-                            SE, BE: next_state = STOP_CS;
-                            default: next_state = STOP_CS;
-                        endcase
+                    bit_cnt_n = bit_cnt + {3'b000, lanes};
+                    if (bit_cnt_n >= 6'd32) begin
+                        bit_cnt_n  = 6'd0;
+                        byte_cnt_n = byte_cnt + 4;
+                        if ((byte_cnt + 4) < len_bytes && !tx_empty)
+                            shreg_n = tx_data_fifo;
+                        else
+                            shreg_n = 32'b0;
                     end
+                    if (byte_cnt_n >= len_bytes)
+                        state_n = CS_DONE;
                 end
             end
+        end
 
-            MODE: begin
-                next_sclk_en = 1;
-                if (shift_pulse) next_data_shift_reg = data_shift_reg << lanes;
-                if (bit_tick) begin
-                    next_bit_cnt = bit_cnt + {{29{1'b0}}, lanes};
-                    if (next_bit_cnt >= 8) begin
-                        next_bit_cnt = 0;
-                        if (dummy_cycles!=0) begin
-                            next_state = DUMMY;
-                            next_dummy_left = dummy_cycles;
-                        end else begin
-                            next_state = DATA;
-                            next_lanes = data_lanes_eff;
-                            next_io_oe = dir?4'b0000:((next_lanes==3'd1)?4'b0001:(next_lanes==3'd2)?4'b0011:4'b1111);
-                            next_data_shift_reg = dir?32'b0:tx_data_fifo;
-                            next_byte_cnt = 0;
-                        end
-                    end
-                end
-            end
+        CS_HOLD: begin
+            cs_n_n = 1'b0;
+            if (cs_auto)
+                state_n = CS_DONE;
+        end
 
-            DUMMY: begin
-                next_sclk_en = 1;
-                next_io_oe = 0;
-                if (bit_tick) begin
-                    if (dummy_left>0) next_dummy_left = dummy_left - 1;
-                    if (dummy_left==1) begin
-                        next_state = DATA;
-                        next_lanes = data_lanes_eff;
-                        next_io_oe = dir?4'b0000:((next_lanes==3'd1)?4'b0001:(next_lanes==3'd2)?4'b0011:4'b1111);
-                        next_data_shift_reg = dir?32'b0:tx_data_fifo;
-                        next_byte_cnt = 0;
-                    end
-                end
-            end
+        CS_DONE: begin
+            cs_n_n  = 1'b1;
+            state_n = IDLE;
+        end
 
-            DATA: begin
-                next_sclk_en = 1;
-                if (dir) begin
-                    if (sample_pulse) next_data_shift_reg = (data_shift_reg<<lanes) | {{28{1'b0}}, input_bits};
-                    if (bit_tick) begin
-                        next_bit_cnt = bit_cnt + {{29{1'b0}}, lanes};
-                        if (next_bit_cnt >= 32) begin
-                            if (!rx_full) begin
-                                rx_data_fifo = data_shift_reg;
-                                rx_wen = 1;
-                            end
-                            next_data_shift_reg = 0;
-                            next_byte_cnt = byte_cnt + 4;
-                            next_bit_cnt = 0;
-                        end
-                        if (byte_cnt+4 >= len_bytes) next_state = STOP_CS;
-                    end
-                end else begin
-                    if (shift_pulse) next_data_shift_reg = data_shift_reg<<lanes;
-                    if (bit_tick) begin
-                        next_bit_cnt = bit_cnt + {{29{1'b0}}, lanes};
-                        if (next_bit_cnt >= 32) begin
-                            next_data_shift_reg = tx_data_fifo;
-                            next_byte_cnt = byte_cnt + 4;
-                            next_bit_cnt = 0;
-                        end
-                        if (byte_cnt+4 >= len_bytes) next_state = STOP_CS;
-                    end
-                end
-            end
+        default: state_n = IDLE;
+    endcase
+end
 
-            STOP_CS: begin
-                next_io_oe = 0;
-                next_sclk_en = 0;
-                next_state = IDLE;
-            end
-            default: begin
-                next_state = IDLE;
-            end
-        endcase
-    end
-
-    // tx_ren: request FIFO word
-    assign tx_ren = (state==DATA) & (~dir) & (bit_cnt + {{29{1'b0}}, lanes} >= 32) & (byte_cnt < len_bytes) & ~tx_empty;
+// ------------------------------------------------------------
+// TX FIFO read enable
+// ------------------------------------------------------------
+assign tx_ren = (state==DATA_BIT) && !dir &&
+                (bit_cnt + {3'b000, lanes} >= 6'd32) &&
+                ((byte_cnt + 4) < len_bytes) && !tx_empty;
 
 endmodule
+


### PR DESCRIPTION
## Summary
- Rewrite qspi_fsm with MSB-first shifting for opcode and address
- Add chip-select timing states and continuous-read hold support
- Gate data lanes with quad enable and handle dummy cycles and FIFO handshakes

## Testing
- `verilator --lint-only -Wno-fatal rtl/axi_read_block.v rtl/axi_write_block.v rtl/csr.v rtl/fifo.v rtl/qspi_fsm.v`
- `iverilog -g2012 -s qspi_fsm -o /tmp/qspi_fsm.vvp rtl/axi_read_block.v rtl/axi_write_block.v rtl/csr.v rtl/fifo.v rtl/qspi_fsm.v`
