### PR TITLE
Fix fast read capture and DMA gating

### DIFF
--- a/src/fifo_rx.v
+++ b/src/fifo_rx.v
@@ -23,7 +23,8 @@ module fifo_rx #(
 
   assign full_o   = (count == DEPTH[$clog2(DEPTH):0]);
   assign empty_o  = (count == {($clog2(DEPTH)+1){1'b0}});
-  assign rd_data_o = mem[rd_ptr];
+  reg [WIDTH-1:0] rd_data_r;
+  assign rd_data_o = rd_data_r;
   assign level_o   = count;
 
   always @(posedge clk or negedge resetn) begin
@@ -31,17 +32,17 @@ module fifo_rx #(
       wr_ptr <= {($clog2(DEPTH)){1'b0}};
       rd_ptr <= {($clog2(DEPTH)){1'b0}};
       count  <= {($clog2(DEPTH)+1){1'b0}};
+      rd_data_r <= {WIDTH{1'b0}};
     end else begin
       // write
       if (wr_en_i && !full_o) begin
         mem[wr_ptr] <= wr_data_i;
         wr_ptr <= wr_ptr + {{($clog2(DEPTH)-1){1'b0}},1'b1};
       end
-      // read
       if (rd_en_i && !empty_o) begin
+        rd_data_r <= mem[rd_ptr];
         rd_ptr <= rd_ptr + {{($clog2(DEPTH)-1){1'b0}},1'b1};
       end
-      // update count
       case ({wr_en_i && !full_o, rd_en_i && !empty_o})
         2'b10: count <= count + {{($clog2(DEPTH)){1'b0}},1'b1};
         2'b01: count <= count - {{($clog2(DEPTH)){1'b0}},1'b1};

--- a/src/fifo_tx.v
+++ b/src/fifo_tx.v
@@ -23,14 +23,16 @@ module fifo_tx #(
 
   assign full_o  = (count == DEPTH[$clog2(DEPTH):0]);
   assign empty_o = (count == {($clog2(DEPTH)+1){1'b0}});
-  assign rd_data_o = mem[rd_ptr];
+  reg [WIDTH-1:0] rd_data_r;
+  assign rd_data_o = rd_data_r;
   assign level_o   = count;
 
   always @(posedge clk or negedge resetn) begin
     if (!resetn) begin
-      wr_ptr <= {($clog2(DEPTH)){1'b0}};
-      rd_ptr <= {($clog2(DEPTH)){1'b0}};
-      count  <= {($clog2(DEPTH)+1){1'b0}};
+      wr_ptr    <= {($clog2(DEPTH)){1'b0}};
+      rd_ptr    <= {($clog2(DEPTH)){1'b0}};
+      count     <= {($clog2(DEPTH)+1){1'b0}};
+      rd_data_r <= {WIDTH{1'b0}};
     end else begin
       // write
       if (wr_en_i && !full_o) begin
@@ -39,6 +41,7 @@ module fifo_tx #(
       end
       // read
       if (rd_en_i && !empty_o) begin
+        rd_data_r <= mem[rd_ptr];
         rd_ptr <= rd_ptr + {{($clog2(DEPTH)-1){1'b0}},1'b1};
       end
       // update count

--- a/src/qspi_fsm.v
+++ b/src/qspi_fsm.v
@@ -475,11 +475,13 @@ always @* begin
                     dummy_cnt_n = dummy_cnt - 1;
                 if (dummy_cnt == 1) begin
                     if (len_bytes != 0) begin
-                        state_n   = DATA_BIT;
-                        lanes_n   = data_lanes_eff;
-                        shreg_n   = dir ? 32'b0 : tx_data_fifo;
-                        io_oe_n   = dir ? 4'b0000 : lane_mask(data_lanes_eff);
-                        byte_cnt_n = 32'd0;
+                        state_n      = DATA_BIT;
+                        lanes_n      = data_lanes_eff;
+                        shreg_n      = dir ? 32'b0 : tx_data_fifo;
+                        io_oe_n      = dir ? 4'b0000 : lane_mask(data_lanes_eff);
+                        byte_cnt_n   = 32'd0;
+                        rd_warmup_n  = dir ? 1'b1 : 1'b0; // skip first sample after dummy for reads
+                        rd_warmup_cnt_n = 4'd0;
                     end else begin
                         state_n = CS_DONE;
                         cs_cnt_n = {6'd0, cs_delay} + (post_hold_write ? POST_WRITE_HOLD_CYCLES[7:0] : 8'd0);


### PR DESCRIPTION
## Summary
- ensure data phase warm-up after dummy cycles to fix fast read capture
- reset DMA engine when disabled and gate busy status
- register FIFO RX/TX read data and refine CSR pop logic
- allow combined enable+trigger in CTRL writes
- handle RX FIFO latency in DMA write path

## Testing
- `make test`
- `iverilog -g2012 -s checklist_tb -o .sim/checklist_tb.vvp $(tr '\n' ' ' < filelist.f) tb/checklist_tb.v docs/MX25L6436F.txt && vvp .sim/checklist_tb.vvp`
